### PR TITLE
Put shared publishing steps inside a template

### DIFF
--- a/packages/saved-views-client/publish.yaml
+++ b/packages/saved-views-client/publish.yaml
@@ -7,8 +7,9 @@ pr: none
 
 variables:
   - name: packageName
-    value: "saved-views-client"
+    value: saved-views-client
   - name: packageVersion
+    # Build.SourceBranchName will be a tag that triggereed the pipeline, like "v1.2.3"
     value: ${{ replace(variables['Build.SourceBranchName'], 'v', '') }}
   - name: tarballName
     value: itwin-$(packageName)-$(packageVersion).tgz
@@ -20,56 +21,10 @@ resources:
       name: iModelTechnologies/imodeljs-build-pipeline-scripts
 
 stages:
-  - stage: build
-    displayName: Build
-    jobs:
-      - job: Build
-        steps:
-          - checkout: self
-            clean: true
-            fetchDepth: 1
-
-          - task: NodeTool@0
-            displayName: Use Node.js 18.x
-            inputs:
-              versionSpec: 18.x
-
-          - task: CmdLine@2
-            displayName: Install pnpm
-            inputs:
-              script: npm install -g pnpm
-
-          - task: CmdLine@2
-            displayName: Audit
-            inputs:
-              script: pnpm audit --audit-level=high
-
-          - task: CmdLine@2
-            displayName: Install dependencies
-            inputs:
-              script: pnpm install --filter $(packageName)
-
-          - task: CmdLine@2
-            displayName: Build package
-            inputs:
-              script: npm run build
-              workingDirectory: packages/$(packageName)/
-
-          - task: CmdLine@2
-            displayName: Run unit tests
-            inputs:
-              script: npm run test:cover
-              workingDirectory: packages/$(packageName)/
-
-          - task: CmdLine@2
-            displayName: Pack package files
-            inputs:
-             script: pnpm pack
-             workingDirectory: packages/$(packageName)/
-
-          - publish: packages/$(packageName)/$(tarballName)
-            displayName: Publish package artifact
-            artifact: published-package
+  - template: /publish-artifact.yaml
+    parameters:
+      packageName: $(packageName)
+      tarballName: $(tarballName)
 
   - stage: publish
     dependsOn: build

--- a/packages/saved-views-react/publish.yaml
+++ b/packages/saved-views-react/publish.yaml
@@ -9,6 +9,7 @@ variables:
   - name: packageName
     value: saved-views-react
   - name: packageVersion
+    # Build.SourceBranchName will be a tag that triggereed the pipeline, like "v1.2.3"
     value: ${{ replace(variables['Build.SourceBranchName'], 'v', '') }}
   - name: tarballName
     value: itwin-$(packageName)-$(packageVersion).tgz
@@ -20,56 +21,10 @@ resources:
       name: iModelTechnologies/imodeljs-build-pipeline-scripts
 
 stages:
-  - stage: build
-    displayName: Build
-    jobs:
-      - job: Build
-        steps:
-          - checkout: self
-            clean: true
-            fetchDepth: 1
-
-          - task: NodeTool@0
-            displayName: Use Node.js 18.x
-            inputs:
-              versionSpec: 18.x
-
-          - task: CmdLine@2
-            displayName: Install pnpm
-            inputs:
-              script: npm install -g pnpm
-
-          - task: CmdLine@2
-            displayName: Audit
-            inputs:
-              script: pnpm audit --audit-level=high
-
-          - task: CmdLine@2
-            displayName: Install dependencies
-            inputs:
-              script: pnpm install --filter $(packageName)
-
-          - task: CmdLine@2
-            displayName: Build package
-            inputs:
-              script: npm run build
-              workingDirectory: packages/$(packageName)/
-
-          - task: CmdLine@2
-            displayName: Run unit tests
-            inputs:
-              script: npm run test:cover
-              workingDirectory: packages/$(packageName)/
-
-          - task: CmdLine@2
-            displayName: Pack package files
-            inputs:
-             script: pnpm pack
-             workingDirectory: packages/$(packageName)/
-
-          - publish: packages/$(packageName)/$(tarballName)
-            displayName: Publish package artifact
-            artifact: published-package
+  - template: /publish-artifact.yaml
+    parameters:
+      packageName: $(packageName)
+      tarballName: $(tarballName)
 
   - stage: publish
     dependsOn: build

--- a/publish-artifact.yaml
+++ b/publish-artifact.yaml
@@ -1,0 +1,60 @@
+parameters:
+  - name: packageName
+    type: string
+  - name: tarballName
+    type: string
+
+stages:
+  - stage: Publish artifact
+    displayName: Build
+    jobs:
+      - job: Build
+        steps:
+          - checkout: self
+            clean: true
+            fetchDepth: 1
+
+          - task: NodeTool@0
+            displayName: Use Node.js 18.x
+            inputs:
+              versionSpec: 18.x
+
+          - task: CmdLine@2
+            displayName: Install pnpm
+            inputs:
+              script: npm install -g pnpm
+
+          - task: CmdLine@2
+            displayName: Audit
+            inputs:
+              script: pnpm audit --audit-level=high
+
+          - task: CmdLine@2
+            displayName: Install dependencies
+            inputs:
+              script: pnpm install --filter ${{ parameters.packageName }}
+
+          - task: CmdLine@2
+            displayName: Build package
+            inputs:
+              script: npm run build
+              workingDirectory: packages/${{ parameters.packageName }}/
+
+          - task: CmdLine@2
+            displayName: Run unit tests
+            inputs:
+              script: npm run test:cover
+              workingDirectory: packages/${{ parameters.packageName }}/
+
+      - job: Publish
+        dependsOn: Build
+        steps:
+          - task: CmdLine@2
+            displayName: Pack package files
+            inputs:
+             script: pnpm pack
+             workingDirectory: packages/${{ parameters.packageName }}/
+
+          - publish: packages/${{ parameters.packageName }}/${{ parameters.tarballName }}
+            displayName: Publish package artifact
+            artifact: published-package


### PR DESCRIPTION
The two public packages in this repository redeclare same build steps as part of their publishing pipeline. Create a pipeline template at the repository root that holds this shared logic and use it for both packages.