### PR TITLE
Fix Azure pipeline stage defintion

### DIFF
--- a/publish-artifact.yaml
+++ b/publish-artifact.yaml
@@ -5,7 +5,7 @@ parameters:
     type: string
 
 stages:
-  - stage: Publish artifact
+  - stage: PublishArtifact
     displayName: Build
     jobs:
       - job: Build


### PR DESCRIPTION
Azure pipeline stage names are only allowed to use symbols that fall into A-Z, a-z, 0-9, or _ category but we had a space in it. [Relevant Azure pipeline documentation](https://learn.microsoft.com/en-us/azure/devops/pipelines/process/stages?view=azure-devops&tabs=yaml#specify-stages).