### PR TITLE
Fix release pipeline

### DIFF
--- a/packages/saved-views-client/publish.yaml
+++ b/packages/saved-views-client/publish.yaml
@@ -27,8 +27,8 @@ stages:
       tarballName: $(tarballName)
 
   - stage: publish
-    dependsOn: build
-    displayName: Publish
+    dependsOn: PublishArtifact
+    displayName: Publish package to npmjs
     jobs:
       - template: templates/npmjs-publish-deployment.yaml@templates
         parameters:

--- a/packages/saved-views-react/publish.yaml
+++ b/packages/saved-views-react/publish.yaml
@@ -27,8 +27,8 @@ stages:
       tarballName: $(tarballName)
 
   - stage: publish
-    dependsOn: build
-    displayName: Publish
+    dependsOn: PublishArtifact
+    displayName: Publish package to npmjs
     jobs:
       - template: templates/npmjs-publish-deployment.yaml@templates
         parameters:

--- a/publish-artifact.yaml
+++ b/publish-artifact.yaml
@@ -6,7 +6,7 @@ parameters:
 
 stages:
   - stage: PublishArtifact
-    displayName: Build
+    displayName: Build and publish artifact
     jobs:
       - job: Build
         steps:


### PR DESCRIPTION
* Azure pipeline definitions
    * Update stage name upon which package publishing stage depends.
    * Update stage display names to be more accurate.
* Release script
    * Include package identifier in generated release tags, i.e. `-client` or `-react`.
    * Rename `version` variable to `versionBump` to make it clearer what the variable contains. 