### PR TITLE
Fix publishing pipeline template

### DIFF
--- a/publish-artifact.yaml
+++ b/publish-artifact.yaml
@@ -8,7 +8,7 @@ stages:
   - stage: PublishArtifact
     displayName: Build and publish artifact
     jobs:
-      - job: Build
+      - job: BuildAndPublish
         steps:
           - checkout: self
             clean: true
@@ -46,9 +46,6 @@ stages:
               script: npm run test:cover
               workingDirectory: packages/${{ parameters.packageName }}/
 
-      - job: Publish
-        dependsOn: Build
-        steps:
           - task: CmdLine@2
             displayName: Pack package files
             inputs:


### PR DESCRIPTION
Tasks in separate jobs do not share the same context, thus when the time came to pack files for publishing, the second job failed because it could not find pnpm installed.

Join the two jobs together to fix the problem.