### PR TITLE
Warn user when access token is about to expire

### DIFF
--- a/packages/test-app-frontend/src/App/App.tsx
+++ b/packages/test-app-frontend/src/App/App.tsx
@@ -160,17 +160,12 @@ function SignInPrompt(props: SignInPromptProps): ReactElement {
 
 function useBackgroundITwinJsAppLoading(): typeof ITwinJsApp | undefined {
   const [itwinJsApp, setITwinJsApp] = useState<typeof ITwinJsApp>();
-  const { authorizationClient } = useAuthorization();
   useEffect(
     () => {
-      if (!authorizationClient) {
-        return;
-      }
-
       let disposed = false;
       void (async () => {
         const { ITwinJsApp, initializeITwinJsApp } = await import("./ITwinJsApp/ITwinJsApp.js");
-        await initializeITwinJsApp(authorizationClient);
+        await initializeITwinJsApp();
         if (!disposed) {
           setITwinJsApp(() => ITwinJsApp);
         }
@@ -178,7 +173,7 @@ function useBackgroundITwinJsAppLoading(): typeof ITwinJsApp | undefined {
 
       return () => { disposed = true; };
     },
-    [authorizationClient],
+    [],
   );
   return itwinJsApp;
 }
@@ -188,15 +183,14 @@ interface OpenIModelProps {
 }
 
 function OpenIModel(props: OpenIModelProps): ReactElement | null {
-  const { authorizationClient } = useAuthorization();
   const { iTwinId, iModelId } = useParams<{ iTwinId: string; iModelId: string; }>();
   if (iTwinId === undefined || iModelId === undefined) {
     return null;
   }
 
-  if (props.iTwinJsApp === undefined || authorizationClient === undefined) {
+  if (props.iTwinJsApp === undefined) {
     return <LoadingScreen>Initializing...</LoadingScreen>;
   }
 
-  return <props.iTwinJsApp iTwinId={iTwinId} iModelId={iModelId} authorizationClient={authorizationClient} />;
+  return <props.iTwinJsApp iTwinId={iTwinId} iModelId={iModelId} />;
 }

--- a/packages/test-app-frontend/src/App/App.tsx
+++ b/packages/test-app-frontend/src/App/App.tsx
@@ -8,19 +8,18 @@ import { Button, SideNavigation, SidenavButton, Surface, ThemeProvider } from "@
 import { PropsWithChildren, ReactElement, useEffect, useState } from "react";
 import { Navigate, Outlet, Route, Routes, useMatch, useNavigate, useParams } from "react-router-dom";
 
-import { applyUrlPrefix, clientId } from "../environment";
-import { AppContext, appContext } from "./AppContext";
-import { AppHeader } from "./AppHeader";
+import { applyUrlPrefix, clientId } from "../environment.js";
+import { AppContext, appContext } from "./AppContext.js";
+import { AppHeader } from "./AppHeader.js";
 import {
-  AuthorizationState, SignInCallback, SignInSilent, SignInSilentCallback, createAuthorizationProvider,
-  useAuthorization,
-} from "./Authorization";
-import { ComponentsCatalogRoutes } from "./ComponentsCatalog/ComponentsCatalog";
-import type { ITwinJsApp } from "./ITwinJsApp/ITwinJsApp";
-import { LoadingScreen } from "./common/LoadingScreen";
-import { ErrorPage } from "./errors/ErrorPage";
-import { IModelBrowser } from "./imodel-browser/IModelBrowser";
-import { ITwinBrowser } from "./imodel-browser/ITwinBrowser";
+  AuthorizationState, SignInCallback, SignInSilent, SignInSilentCallback, createAuthorizationProvider, useAuthorization,
+} from "./Authorization.js";
+import { ComponentsCatalogRoutes } from "./ComponentsCatalog/ComponentsCatalog.js";
+import type { ITwinJsApp } from "./ITwinJsApp/ITwinJsApp.js";
+import { LoadingScreen } from "./common/LoadingScreen.js";
+import { ErrorPage } from "./errors/ErrorPage.js";
+import { IModelBrowser } from "./imodel-browser/IModelBrowser.js";
+import { ITwinBrowser } from "./imodel-browser/ITwinBrowser.js";
 
 import "@itwin/itwinui-react/styles.css";
 import "./App.css";
@@ -33,8 +32,8 @@ export function App(): ReactElement {
 
   return (
     <appContext.Provider value={appContextValue}>
-      <AuthorizationProvider>
-        <ThemeProvider theme={appContextValue.theme}>
+      <ThemeProvider theme={appContextValue.theme}>
+        <AuthorizationProvider>
           <PageLayout>
             <PageLayout.Header>
               <AppHeader />
@@ -45,8 +44,8 @@ export function App(): ReactElement {
               <Route path="/*" element={<><SignInSilent /><Main /></>} />
             </Routes>
           </PageLayout>
-        </ThemeProvider>
-      </AuthorizationProvider>
+        </AuthorizationProvider>
+      </ThemeProvider>
     </appContext.Provider>
   );
 }

--- a/packages/test-app-frontend/src/App/App.tsx
+++ b/packages/test-app-frontend/src/App/App.tsx
@@ -161,17 +161,17 @@ function SignInPrompt(props: SignInPromptProps): ReactElement {
 
 function useBackgroundITwinJsAppLoading(): typeof ITwinJsApp | undefined {
   const [itwinJsApp, setITwinJsApp] = useState<typeof ITwinJsApp>();
-  const { userAuthorizationClient } = useAuthorization();
+  const { authorizationClient } = useAuthorization();
   useEffect(
     () => {
-      if (!userAuthorizationClient) {
+      if (!authorizationClient) {
         return;
       }
 
       let disposed = false;
       void (async () => {
         const { ITwinJsApp, initializeITwinJsApp } = await import("./ITwinJsApp/ITwinJsApp.js");
-        await initializeITwinJsApp(userAuthorizationClient);
+        await initializeITwinJsApp(authorizationClient);
         if (!disposed) {
           setITwinJsApp(() => ITwinJsApp);
         }
@@ -179,7 +179,7 @@ function useBackgroundITwinJsAppLoading(): typeof ITwinJsApp | undefined {
 
       return () => { disposed = true; };
     },
-    [userAuthorizationClient],
+    [authorizationClient],
   );
   return itwinJsApp;
 }
@@ -189,15 +189,15 @@ interface OpenIModelProps {
 }
 
 function OpenIModel(props: OpenIModelProps): ReactElement | null {
-  const { userAuthorizationClient } = useAuthorization();
+  const { authorizationClient } = useAuthorization();
   const { iTwinId, iModelId } = useParams<{ iTwinId: string; iModelId: string; }>();
   if (iTwinId === undefined || iModelId === undefined) {
     return null;
   }
 
-  if (props.iTwinJsApp === undefined || userAuthorizationClient === undefined) {
+  if (props.iTwinJsApp === undefined || authorizationClient === undefined) {
     return <LoadingScreen>Initializing...</LoadingScreen>;
   }
 
-  return <props.iTwinJsApp iTwinId={iTwinId} iModelId={iModelId} authorizationClient={userAuthorizationClient} />;
+  return <props.iTwinJsApp iTwinId={iTwinId} iModelId={iModelId} authorizationClient={authorizationClient} />;
 }

--- a/packages/test-app-frontend/src/App/AppHeader.tsx
+++ b/packages/test-app-frontend/src/App/AppHeader.tsx
@@ -14,7 +14,7 @@ import { AuthorizationState, useAuthorization } from "./Authorization";
 import { GetUserProfileResult, getUserProfile } from "./ITwinApi";
 
 export function AppHeader(): ReactElement {
-  const { state, signIn, signOut, userAuthorizationClient } = useAuthorization();
+  const { state, signIn, signOut, authorizationClient } = useAuthorization();
   const navigate = useNavigate();
 
   const [user, setUser] = useState<UserProfile>();
@@ -26,7 +26,7 @@ export function AppHeader(): ReactElement {
 
       let disposed = false;
       void (async () => {
-        const profile = await getUserProfile({ authorizationClient: userAuthorizationClient });
+        const profile = await getUserProfile({ authorizationClient });
         if (!disposed) {
           setUser(profile?.user);
         }
@@ -34,7 +34,7 @@ export function AppHeader(): ReactElement {
 
       return () => { disposed = true; };
     },
-    [state, userAuthorizationClient],
+    [state, authorizationClient],
   );
 
   const actions = [

--- a/packages/test-app-frontend/src/App/Authorization.tsx
+++ b/packages/test-app-frontend/src/App/Authorization.tsx
@@ -137,7 +137,7 @@ function SignInPopupPrompt(props: SignInPopupPromptProps): ReactElement {
       justifyContent: "space-between",
       grid: "1fr / 250px auto",
       alignItems: "center",
-      gap: "var(--iui-size-s)"
+      gap: "var(--iui-size-s)",
     }}>
       {props.text}
       <Button styleType="high-visibility" onClick={props.onClick}>Sign in</Button>

--- a/packages/test-app-frontend/src/App/Authorization.tsx
+++ b/packages/test-app-frontend/src/App/Authorization.tsx
@@ -2,19 +2,18 @@
 * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
-import { AccessToken } from "@itwin/core-bentley";
-import { AuthorizationClient } from "@itwin/core-common";
+import type { AuthorizationClient } from "@itwin/core-common";
 import { Code } from "@itwin/itwinui-react";
-import { User, UserManager, WebStorageStateStore } from "oidc-client-ts";
+import { UserManager, WebStorageStateStore, type User } from "oidc-client-ts";
 import {
-  ComponentType, createContext, Fragment, PropsWithChildren, ReactElement, ReactNode, useContext, useEffect, useRef,
-  useState,
+  Fragment, createContext, useContext, useEffect, useRef, useState, type ComponentType, type PropsWithChildren,
+  type ReactElement, type ReactNode,
 } from "react";
 import { useNavigate } from "react-router-dom";
 
-import { applyUrlPrefix } from "../environment";
-import { LoadingScreen } from "./common/LoadingScreen";
-import { ErrorPage } from "./errors/ErrorPage";
+import { applyUrlPrefix } from "../environment.js";
+import { LoadingScreen } from "./common/LoadingScreen.js";
+import { ErrorPage } from "./errors/ErrorPage.js";
 
 export interface AuthorizationProviderConfig {
   authority: string;
@@ -64,7 +63,7 @@ export function createAuthorizationProvider(config: AuthorizationProviderConfig)
     const [authorizationContextValue, setAuthorizationContextValue] = useState<AuthorizationContext>({
       state: AuthorizationState.Pending,
       user: undefined,
-      userAuthorizationClient: undefined,
+      authorizationClient: undefined,
       signIn,
       signOut,
     });
@@ -75,7 +74,7 @@ export function createAuthorizationProvider(config: AuthorizationProviderConfig)
         setAuthorizationContextValue({
           state: AuthorizationState.SignedIn,
           user,
-          userAuthorizationClient: new AuthClient(userManager),
+          authorizationClient: new AuthClient(userManager),
           signIn,
           signOut,
         });
@@ -88,7 +87,7 @@ export function createAuthorizationProvider(config: AuthorizationProviderConfig)
           setAuthorizationContextValue({
             state: AuthorizationState.SignedOut,
             user: undefined,
-            userAuthorizationClient: undefined,
+            authorizationClient: undefined,
             signIn,
             signOut,
           });
@@ -128,13 +127,13 @@ interface InternalAuthorizationContext {
 interface AuthorizationContextWithUser {
   state: AuthorizationState.SignedIn;
   user: User;
-  userAuthorizationClient: AuthorizationClient;
+  authorizationClient: AuthorizationClient;
 }
 
 interface AuthorizationContextWithoutUser {
   state: Exclude<AuthorizationState, AuthorizationState.SignedIn>;
   user: undefined;
-  userAuthorizationClient: undefined;
+  authorizationClient: undefined;
 }
 
 export enum AuthorizationState {
@@ -147,7 +146,7 @@ export enum AuthorizationState {
 class AuthClient implements AuthorizationClient {
   constructor(private userManager: UserManager) { }
 
-  public async getAccessToken(): Promise<AccessToken> {
+  public async getAccessToken(): Promise<string> {
     const user = await this.userManager.getUser();
     return user ? `${user.token_type} ${user.access_token}` : "";
   }
@@ -161,7 +160,7 @@ export function useAuthorization(): AuthorizationContext {
 const authorizationContext = createContext<AuthorizationContext>({
   state: AuthorizationState.Offline,
   user: undefined,
-  userAuthorizationClient: undefined,
+  authorizationClient: undefined,
   signIn: async () => { },
   signOut: async () => { },
 });

--- a/packages/test-app-frontend/src/App/Authorization.tsx
+++ b/packages/test-app-frontend/src/App/Authorization.tsx
@@ -3,10 +3,10 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 import type { AuthorizationClient } from "@itwin/core-common";
-import { Code } from "@itwin/itwinui-react";
+import { Button, Code, useToaster } from "@itwin/itwinui-react";
 import { UserManager, WebStorageStateStore, type User } from "oidc-client-ts";
 import {
-  Fragment, createContext, useContext, useEffect, useRef, useState, type ComponentType, type PropsWithChildren,
+  Fragment, createContext, useContext, useEffect, useMemo, useRef, useState, type ComponentType, type PropsWithChildren,
   type ReactElement, type ReactNode,
 } from "react";
 import { useNavigate } from "react-router-dom";
@@ -39,18 +39,6 @@ export function createAuthorizationProvider(config: AuthorizationProviderConfig)
     accessTokenExpiringNotificationTimeInSeconds: 120,
     userStore: new WebStorageStateStore({ store: localStorage }),
   });
-  userManager.events.addSilentRenewError((error) => {
-    // eslint-disable-next-line no-console
-    console.warn(error);
-  });
-  userManager.events.addAccessTokenExpiring(async () => {
-    try {
-      await userManager.signinSilent();
-    } catch (error) {
-      // eslint-disable-next-line no-console
-      console.error(`Silent sign in failed: ${error as string}`);
-    }
-  });
 
   const signIn = async () => {
     await userManager.signinRedirect({
@@ -60,10 +48,13 @@ export function createAuthorizationProvider(config: AuthorizationProviderConfig)
   const signOut = async () => userManager.signoutRedirect();
 
   return function AuthorizationProvider(props: PropsWithChildren<unknown>): ReactElement {
+    const toaster = useToaster();
+    const authorizationClient = useMemo(() => new AuthClient(userManager, toaster, signIn), [toaster]);
+
     const [authorizationContextValue, setAuthorizationContextValue] = useState<AuthorizationContext>({
       state: AuthorizationState.Pending,
       user: undefined,
-      authorizationClient: undefined,
+      authorizationClient,
       signIn,
       signOut,
     });
@@ -74,7 +65,7 @@ export function createAuthorizationProvider(config: AuthorizationProviderConfig)
         setAuthorizationContextValue({
           state: AuthorizationState.SignedIn,
           user,
-          authorizationClient: new AuthClient(userManager),
+          authorizationClient,
           signIn,
           signOut,
         });
@@ -83,25 +74,45 @@ export function createAuthorizationProvider(config: AuthorizationProviderConfig)
 
     useEffect(
       () => {
+        const handleSilentRenewError = (error: unknown) => {
+          // eslint-disable-next-line no-console
+          console.warn(error);
+        };
+
+        const handleAccessTokenExpiring = async () => {
+          try {
+            await userManager.signinSilent();
+          } catch (error) {
+            toaster.informational(
+              <SignInPopupPrompt text="Access token is expiring." onClick={signIn} />,
+              { type: "persisting", hasCloseButton: true },
+            );
+          }
+        };
+
         const handleUserUnloaded = () => {
           setAuthorizationContextValue({
             state: AuthorizationState.SignedOut,
             user: undefined,
-            authorizationClient: undefined,
+            authorizationClient,
             signIn,
             signOut,
           });
         };
 
+        userManager.events.addSilentRenewError(handleSilentRenewError);
+        userManager.events.addAccessTokenExpiring(handleAccessTokenExpiring);
         userManager.events.addUserLoaded(internalAuthorizationContextValue.loadUser);
         userManager.events.addUserUnloaded(handleUserUnloaded);
 
         return () => {
+          userManager.events.removeSilentRenewError(handleSilentRenewError);
+          userManager.events.removeAccessTokenExpiring(handleAccessTokenExpiring);
           userManager.events.removeUserLoaded(internalAuthorizationContextValue.loadUser);
           userManager.events.removeUserUnloaded(handleUserUnloaded);
         };
       },
-      [internalAuthorizationContextValue],
+      [internalAuthorizationContextValue, authorizationClient, toaster],
     );
 
     return (
@@ -114,7 +125,28 @@ export function createAuthorizationProvider(config: AuthorizationProviderConfig)
   };
 }
 
+interface SignInPopupPromptProps {
+  text: string;
+  onClick: () => void;
+}
+
+function SignInPopupPrompt(props: SignInPopupPromptProps): ReactElement {
+  return (
+    <div style={{
+      display: "grid",
+      justifyContent: "space-between",
+      grid: "1fr / 250px auto",
+      alignItems: "center",
+      gap: "var(--iui-size-s)"
+    }}>
+      {props.text}
+      <Button styleType="high-visibility" onClick={props.onClick}>Sign in</Button>
+    </div>
+  );
+}
+
 export type AuthorizationContext = {
+  authorizationClient: AuthorizationClient;
   signIn: () => Promise<void>;
   signOut: () => Promise<void>;
 } & (AuthorizationContextWithUser | AuthorizationContextWithoutUser);
@@ -127,13 +159,11 @@ interface InternalAuthorizationContext {
 interface AuthorizationContextWithUser {
   state: AuthorizationState.SignedIn;
   user: User;
-  authorizationClient: AuthorizationClient;
 }
 
 interface AuthorizationContextWithoutUser {
   state: Exclude<AuthorizationState, AuthorizationState.SignedIn>;
   user: undefined;
-  authorizationClient: undefined;
 }
 
 export enum AuthorizationState {
@@ -144,10 +174,26 @@ export enum AuthorizationState {
 }
 
 class AuthClient implements AuthorizationClient {
-  constructor(private userManager: UserManager) { }
+  constructor(
+    private userManager: UserManager,
+    private toaster: ReturnType<typeof useToaster>,
+    private signIn: () => Promise<void>,
+  ) { }
 
   public async getAccessToken(): Promise<string> {
     const user = await this.userManager.getUser();
+    if (user?.expired) {
+      return new Promise((resolve, reject) => {
+        const { close } = this.toaster.informational(
+          <SignInPopupPrompt
+            text="You are not signed in."
+            onClick={() => this.signIn().then(() => resolve(this.getAccessToken())).then(close)}
+          />,
+          { type: "persisting", hasCloseButton: true, onRemove: reject },
+        );
+      });
+    }
+
     return user ? `${user.token_type} ${user.access_token}` : "";
   }
 }
@@ -160,7 +206,7 @@ export function useAuthorization(): AuthorizationContext {
 const authorizationContext = createContext<AuthorizationContext>({
   state: AuthorizationState.Offline,
   user: undefined,
-  authorizationClient: undefined,
+  authorizationClient: { getAccessToken: async () => "" },
   signIn: async () => { },
   signOut: async () => { },
 });

--- a/packages/test-app-frontend/src/App/ITwinApi.ts
+++ b/packages/test-app-frontend/src/App/ITwinApi.ts
@@ -2,8 +2,9 @@
 * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
-import { AuthorizationClient } from "@itwin/core-common";
-import { applyUrlPrefix } from "../environment";
+import type { AuthorizationClient } from "@itwin/core-common";
+
+import { applyUrlPrefix } from "../environment.js";
 
 export interface GetUserProfileResult {
   user: {

--- a/packages/test-app-frontend/src/App/ITwinJsApp/ITwinJsApp.tsx
+++ b/packages/test-app-frontend/src/App/ITwinJsApp/ITwinJsApp.tsx
@@ -9,7 +9,7 @@ import {
   type AuthorizationClient,
 } from "@itwin/core-common";
 import {
-  CheckpointConnection, IModelApp, IModelConnection, ScreenViewport, ViewCreator3d, ViewState
+  CheckpointConnection, IModelApp, IModelConnection, ScreenViewport, ViewCreator3d, ViewState,
 } from "@itwin/core-frontend";
 import { ITwinLocalization } from "@itwin/core-i18n";
 import { UiCore } from "@itwin/core-react";

--- a/packages/test-app-frontend/src/App/imodel-browser/IModelBrowser.tsx
+++ b/packages/test-app-frontend/src/App/imodel-browser/IModelBrowser.tsx
@@ -13,18 +13,18 @@ import { getIModelThumbnail, getITwinIModels, GetITwinIModelsResult } from "../I
 
 export function IModelBrowser(): ReactElement {
   const { iTwinId } = useParams<{ iTwinId: string; }>();
-  const { userAuthorizationClient } = useAuthorization();
+  const { authorizationClient } = useAuthorization();
   const [iModels, setiModels] = useState<GetITwinIModelsResult["iModels"]>();
 
   useEffect(
     () => {
-      if (iTwinId === undefined || userAuthorizationClient === undefined) {
+      if (iTwinId === undefined || authorizationClient === undefined) {
         return;
       }
 
       let disposed = false;
       void (async () => {
-        const result = await getITwinIModels({ iTwinId }, { authorizationClient: userAuthorizationClient });
+        const result = await getITwinIModels({ iTwinId }, { authorizationClient });
         if (!disposed) {
           setiModels(result?.iModels);
         }
@@ -32,10 +32,10 @@ export function IModelBrowser(): ReactElement {
 
       return () => { disposed = true; };
     },
-    [iTwinId, userAuthorizationClient],
+    [iTwinId, authorizationClient],
   );
 
-  if (!iModels || !userAuthorizationClient) {
+  if (!iModels || !authorizationClient) {
     return <LoadingScreen>Loading content...</LoadingScreen>;
   }
 
@@ -49,7 +49,7 @@ export function IModelBrowser(): ReactElement {
             iModelId={iModel.id}
             name={iModel.name}
             description={iModel.description ?? undefined}
-            authorizationClient={userAuthorizationClient}
+            authorizationClient={authorizationClient}
           />
         ))}
       </FluidGrid>

--- a/packages/test-app-frontend/src/App/imodel-browser/IModelBrowser.tsx
+++ b/packages/test-app-frontend/src/App/imodel-browser/IModelBrowser.tsx
@@ -4,7 +4,7 @@
 *--------------------------------------------------------------------------------------------*/
 import { ReactElement, ReactNode, useEffect, useRef, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
-import { AuthorizationClient } from "@itwin/core-common";
+import type { AuthorizationClient } from "@itwin/core-common";
 import { FluidGrid, PageLayout } from "@itwin/itwinui-layouts-react";
 import { Text, Tile } from "@itwin/itwinui-react";
 import { useAuthorization } from "../Authorization";
@@ -18,7 +18,7 @@ export function IModelBrowser(): ReactElement {
 
   useEffect(
     () => {
-      if (iTwinId === undefined || authorizationClient === undefined) {
+      if (iTwinId === undefined) {
         return;
       }
 
@@ -35,7 +35,7 @@ export function IModelBrowser(): ReactElement {
     [iTwinId, authorizationClient],
   );
 
-  if (!iModels || !authorizationClient) {
+  if (!iModels) {
     return <LoadingScreen>Loading content...</LoadingScreen>;
   }
 
@@ -74,7 +74,7 @@ export function IModelTile(props: IModelTileProps): ReactElement {
     () => {
       const element = divRef.current;
       const authorizationClient = props.authorizationClient;
-      if (thumbnail !== undefined || !element || !authorizationClient) {
+      if (thumbnail !== undefined || !element) {
         return;
       }
 

--- a/packages/test-app-frontend/src/App/imodel-browser/ITwinBrowser.tsx
+++ b/packages/test-app-frontend/src/App/imodel-browser/ITwinBrowser.tsx
@@ -13,18 +13,18 @@ import { getRecentITwins, GetRecentITwinsResult } from "../ITwinApi";
 
 export function ITwinBrowser(): ReactElement {
   const navigate = useNavigate();
-  const { userAuthorizationClient } = useAuthorization();
+  const { authorizationClient } = useAuthorization();
   const [iTwins, setITwins] = useState<GetRecentITwinsResult["iTwins"]>();
 
   useEffect(
     () => {
-      if (userAuthorizationClient === undefined) {
+      if (authorizationClient === undefined) {
         return;
       }
 
       let disposed = false;
       void (async () => {
-        const result = await getRecentITwins({ authorizationClient: userAuthorizationClient });
+        const result = await getRecentITwins({ authorizationClient });
         if (!disposed) {
           setITwins(result?.iTwins);
         }
@@ -32,7 +32,7 @@ export function ITwinBrowser(): ReactElement {
 
       return () => { disposed = true; };
     },
-    [userAuthorizationClient],
+    [authorizationClient],
   );
 
   if (iTwins === undefined) {

--- a/packages/test-app-frontend/src/App/imodel-browser/ITwinBrowser.tsx
+++ b/packages/test-app-frontend/src/App/imodel-browser/ITwinBrowser.tsx
@@ -2,14 +2,15 @@
 * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
-import { ReactElement, useEffect, useState } from "react";
-import { useNavigate } from "react-router-dom";
 import { SvgProject } from "@itwin/itwinui-icons-react";
 import { FluidGrid, Grid, PageLayout } from "@itwin/itwinui-layouts-react";
 import { Surface, Text, Tile } from "@itwin/itwinui-react";
-import { useAuthorization } from "../Authorization";
-import { LoadingScreen } from "../common/LoadingScreen";
-import { getRecentITwins, GetRecentITwinsResult } from "../ITwinApi";
+import { useEffect, useState, type ReactElement } from "react";
+import { useNavigate } from "react-router-dom";
+
+import { useAuthorization } from "../Authorization.js";
+import { LoadingScreen } from "../common/LoadingScreen.js";
+import { getRecentITwins, GetRecentITwinsResult } from "../ITwinApi.js";
 
 export function ITwinBrowser(): ReactElement {
   const navigate = useNavigate();
@@ -18,10 +19,6 @@ export function ITwinBrowser(): ReactElement {
 
   useEffect(
     () => {
-      if (authorizationClient === undefined) {
-        return;
-      }
-
       let disposed = false;
       void (async () => {
         const result = await getRecentITwins({ authorizationClient });

--- a/packages/test-app-frontend/src/main.tsx
+++ b/packages/test-app-frontend/src/main.tsx
@@ -4,10 +4,14 @@
 *--------------------------------------------------------------------------------------------*/
 import { render } from "react-dom";
 import { BrowserRouter } from "react-router-dom";
-import { App } from "./App/App";
+
+import { App } from "./App/App.js";
 
 import "@bentley/icons-generic-webfont/dist/bentley-icons-generic-webfont.css";
 import "@itwin/itwinui-layouts-css/styles.css";
 import "./index.css";
 
-render(<BrowserRouter><App /></BrowserRouter>, document.getElementById("root") as HTMLElement);
+const root = document.getElementById("root");
+if (root) {
+  render(<BrowserRouter><App /></BrowserRouter>, root);
+}


### PR DESCRIPTION
Update test app authorization code to add a warning notification when the user access token is about to expire. Additionally, rename `userAuthorizationClient` to `authorizationClient` and make it non-nullable. Instead, the client will always be present but it will check whether the token is valid at the moment `getAccessToken` is called.