### PR TITLE
Fix usage of css layers

### DIFF
--- a/packages/saved-views-react/CHANGELOG.md
+++ b/packages/saved-views-react/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased](https://github.com/iTwin/saved-views/tree/HEAD/packages/saved-views-react)
 
+### Breaking changes
+
+* Component CSS styles are now scoped to `itwin-svr` CSS layer.
+
 ## [0.1.0](https://github.com/iTwin/saved-views/tree/v0.1.0-react/packages/saved-views-react) - 2024-02-02
 
 Initial package release.

--- a/packages/saved-views-react/src/LayeredDropdownMenu/LayeredDropdownMenu.css
+++ b/packages/saved-views-react/src/LayeredDropdownMenu/LayeredDropdownMenu.css
@@ -2,8 +2,12 @@
 * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
-.svr-layered-dropdown--back {
-  display: flex;
-  gap: var(--iui-size-s);
-  align-items: center;
+@layer itwinui;
+
+@layer itwin-svr {
+  .svr-layered-dropdown--back {
+    display: flex;
+    gap: var(--iui-size-s);
+    align-items: center;
+  }
 }

--- a/packages/saved-views-react/src/SavedViewTile/SavedViewOptions.css
+++ b/packages/saved-views-react/src/SavedViewTile/SavedViewOptions.css
@@ -2,23 +2,26 @@
 * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
+@layer itwinui;
 
-.svr-searchable-submenu {
-  display: grid;
-  grid: auto minmax(0, 1fr) / 1fr;
-  gap: var(--iui-size-xs);
-  height: calc(var(--iui-menu-max-height) - 2 * var(--iui-component-height) - 1px);
-  user-select: none;
-}
+@layer itwin-svr {
+  .svr-searchable-submenu {
+    display: grid;
+    grid: auto minmax(0, 1fr) / 1fr;
+    gap: var(--iui-size-xs);
+    height: calc(var(--iui-menu-max-height) - 2 * var(--iui-component-height) - 1px);
+    user-select: none;
+  }
 
-.svr-searchable-submenu > div {
-  overflow: auto;
-}
+  .svr-searchable-submenu > div {
+    overflow: auto;
+  }
 
-.svr-searchable-submenu-item {
-  width: calc(10 * var(--iui-size-l));
-}
+  .svr-searchable-submenu-item {
+    width: calc(10 * var(--iui-size-l));
+  }
 
-.svr-semibold {
-  font-weight: var(--iui-font-weight-semibold);
+  .svr-semibold {
+    font-weight: var(--iui-font-weight-semibold);
+  }
 }

--- a/packages/saved-views-react/src/SavedViewTile/SavedViewTile.css
+++ b/packages/saved-views-react/src/SavedViewTile/SavedViewTile.css
@@ -2,86 +2,89 @@
 * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
+@layer itwinui;
 
-.svr-tile {
-  width: var(--itwin-svr-tile-width, calc(8 * var(--iui-size-xl)));
-}
+@layer itwin-svr {
+  .svr-tile {
+    width: var(--itwin-svr-tile-width, calc(8 * var(--iui-size-xl)));
+  }
 
-.svr-tile .svr-tile-thumbnail {
-  height: var(--itwin-svr-thumbnail-height, calc(4 * var(--iui-size-xl)));
-}
+  .svr-tile .svr-tile-thumbnail {
+    height: var(--itwin-svr-thumbnail-height, calc(4 * var(--iui-size-xl)));
+  }
 
-.svr-tile .svr-tile-name {
-  height: calc(var(--iui-size-l) + 2px);
-  user-select: unset;
-}
+  .svr-tile .svr-tile-name {
+    height: calc(var(--iui-size-l) + 2px);
+    user-select: unset;
+  }
 
-.svr-tile--metadata {
-  display: grid;
-  grid: 1fr / auto minmax(0, 1fr) auto;
-  align-items: center;
-}
+  .svr-tile--metadata {
+    display: grid;
+    grid: 1fr / auto minmax(0, 1fr) auto;
+    align-items: center;
+  }
 
-.svr-tile--metadata > svg {
-  margin-right: var(--iui-size-xs);
-}
+  .svr-tile--metadata > svg {
+    margin-right: var(--iui-size-xs);
+  }
 
-.svr-tile--tag-container {
-  display: flex;
-  gap: var(--iui-size-s);
-}
+  .svr-tile--tag-container {
+    display: flex;
+    gap: var(--iui-size-s);
+  }
 
-.svr-tile--tag {
-  align-items: center;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  overflow: hidden;
-  min-width: 0;
-}
+  .svr-tile--tag {
+    align-items: center;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
+    min-width: 0;
+  }
 
-.svr-tile--tag-overflow {
-  margin-left: var(--iui-size-s);
-}
+  .svr-tile--tag-overflow {
+    margin-left: var(--iui-size-s);
+  }
 
-.svr-tile--more-options {
-  z-index: 2;
-  grid-area: 1 / 1 / -1 / -1;
-  place-self: end;
-  margin: 0;
-  margin-inline-end: calc(-1*var(--iui-size-2xs));
-  display: grid;
-  position: absolute;
-}
+  .svr-tile--more-options {
+    z-index: 2;
+    grid-area: 1 / 1 / -1 / -1;
+    place-self: end;
+    margin: 0;
+    margin-inline-end: calc(-1*var(--iui-size-2xs));
+    display: grid;
+    position: absolute;
+  }
 
-.svr-tile:not(:hover, :focus-within) .svr-tile--more-options:where(:not(.svr-visible)) {
-  visibility: hidden;
-}
+  .svr-tile:not(:hover, :focus-within) .svr-tile--more-options:where(:not(.svr-visible)) {
+    visibility: hidden;
+  }
 
-.svr-tile--icon-container {
-  display: flex;
-  margin-top: calc(0.5 * var(--iui-size-s));
-  margin-inline: var(--iui-size-xs);
-  gap: var(--iui-size-2xs);
-  z-index: 1;
-}
+  .svr-tile--icon-container {
+    display: flex;
+    margin-top: calc(0.5 * var(--iui-size-s));
+    margin-inline: var(--iui-size-xs);
+    gap: var(--iui-size-2xs);
+    z-index: 1;
+  }
 
-.svr-tile--icon {
-  border-radius: 50%;
-  background: rgb(0, 0, 0, var(--iui-opacity-3));
-  min-width: var(--iui-component-height-small);
-  min-height: var(--iui-component-height-small);
-  display: flex;
-  place-items: center;
-  padding-inline: var(--iui-size-2xs);
-  border: 1px solid transparent;
-}
+  .svr-tile--icon {
+    border-radius: 50%;
+    background: rgb(0, 0, 0, var(--iui-opacity-3));
+    min-width: var(--iui-component-height-small);
+    min-height: var(--iui-component-height-small);
+    display: flex;
+    place-items: center;
+    padding-inline: var(--iui-size-2xs);
+    border: 1px solid transparent;
+  }
 
-.svr-tile--icon svg {
-  fill: var(--iui-color-white);
-}
+  .svr-tile--icon svg {
+    fill: var(--iui-color-white);
+  }
 
-.svr-tile--editable-title > span {
-  display: flex;
-  align-items: center;
-  gap: var(--iui-size-s);
+  .svr-tile--editable-title > span {
+    display: flex;
+    align-items: center;
+    gap: var(--iui-size-s);
+  }
 }

--- a/packages/saved-views-react/src/SavedViewsWidget/SavedViewsExpandableBlockWidget.css
+++ b/packages/saved-views-react/src/SavedViewsWidget/SavedViewsExpandableBlockWidget.css
@@ -2,6 +2,7 @@
 * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
+@layer itwinui;
 
 @layer itwin-svr {
   .svr-saved-views-widget {

--- a/packages/saved-views-react/src/StickyExpandableBlock/StickyExpandableBlock.css
+++ b/packages/saved-views-react/src/StickyExpandableBlock/StickyExpandableBlock.css
@@ -2,17 +2,20 @@
 * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
+@layer itwinui;
 
-.svr-expandable-block-header {
-  position: sticky;
-  top: 0;
-  z-index: 1;
-}
+@layer itwin-svr {
+  .svr-expandable-block-header {
+    position: sticky;
+    top: 0;
+    z-index: 1;
+  }
 
-.svr-expandable-block-header[data-stuck=true] {
-  box-shadow: var(--iui-shadow-1);
-}
+  .svr-expandable-block-header[data-stuck=true] {
+    box-shadow: var(--iui-shadow-1);
+  }
 
-.svr-expandable-block-header:not(:hover) {
-  background: var(--iui-color-background);
+  .svr-expandable-block-header:not(:hover) {
+    background: var(--iui-color-background);
+  }
 }

--- a/packages/saved-views-react/src/TileGrid/TileGrid.css
+++ b/packages/saved-views-react/src/TileGrid/TileGrid.css
@@ -2,6 +2,7 @@
 * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
+@layer itwinui;
 
 @layer itwin-svr {
   .svr-tile-grid {


### PR DESCRIPTION
Our custom CSS styles were being overridden by iTwinUI CSS in some places due to our test app using bad CSS import ordering.

We could have fixed the issue by changing the ordering, but then consumers of `@itwin/saved-views-react` package would have to also be careful to mind the CSS import order. Instead, I declared the existence of `itwinui` [CSS layer](https://developer.mozilla.org/en-US/docs/Web/CSS/@layer) at the beginning of each style sheet so that our `itwin-svr` layer would be applied after it.

Note: This change breaks CSS class name transform in postcss and results in us shipping class names that start with `svr-` instead of `itwin-svr`, which I think isn't a big deal. I could not find a quick way to fix this so we'll decide later if we need more specific prefix to avoid class name collisions.