### PR TITLE
Add view capturing functions

### DIFF
--- a/packages/saved-views-client/CHANGELOG.md
+++ b/packages/saved-views-client/CHANGELOG.md
@@ -6,9 +6,26 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased](https://github.com/iTwin/saved-views/tree/HEAD/packages/saved-views-client)
 
+### Breaking changes
+
+* Remove `SavedViewBase` type
+* Omit `savedViewData` property from `SavedViewListMinimalResponse` type
+* Rename types
+    * `SavedViewWithDataMinimal` -> `SavedViewMinimal`
+    * `SavedViewWithDataRepresentation` -> `SavedViewRepresentation`
+    * `ViewDataItwin3d` -> `ViewDataITwin3d`
+
+### Minor changes
+
+* Add new type guards to discern `ViewData` union members
+    * `isViewDataITwin3d`
+    * `isViewDataITwinDrawing`
+    * `isViewDataITwinSheet`
+
 ### Fixes
 
-* Fix `DELETE` operations throwing due to empty response body.
+* Fix `DELETE` operations throwing due to empty response body
+* Fix being unable to send Saved View to iTwin Saved Views service when `savedViewData` contains URL fields
 
 ## [0.1.0](https://github.com/iTwin/saved-views/tree/v0.1.0-client/packages/saved-views-client) - 2024-02-01
 

--- a/packages/saved-views-client/src/client/SavedViewsClient.ts
+++ b/packages/saved-views-client/src/client/SavedViewsClient.ts
@@ -2,11 +2,11 @@
 * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
-import { Extension, ExtensionListItem, ExtensionMin, ExtensionSavedViewCreate } from "../models/Extension.js";
-import { Group } from "../models/Group.js";
-import { HalLinks } from "../models/Links.js";
-import { Tag } from "../models/Tag.js";
-import { SavedViewWithDataMinimal, SavedViewWithDataRepresentation, ViewData } from "../models/savedViews/View.js";
+import type { Extension, ExtensionListItem, ExtensionMin, ExtensionSavedViewCreate } from "../models/Extension.js";
+import type { Group } from "../models/Group.js";
+import type { HalLinks } from "../models/Links.js";
+import type { Tag } from "../models/Tag.js";
+import type { SavedViewMinimal, SavedViewRepresentation, ViewData } from "../models/savedViews/View.js";
 
 export interface SavedViewsClient {
   getSavedViewMinimal(args: SingleSavedViewParams): Promise<SavedViewMinimalResponse>;
@@ -72,19 +72,19 @@ export interface UpdateSavedViewParams extends CommonRequestParams {
 }
 
 export interface SavedViewMinimalResponse {
-  savedView: SavedViewWithDataMinimal;
+  savedView: SavedViewMinimal;
 }
 
 export interface SavedViewRepresentationResponse {
-  savedView: SavedViewWithDataRepresentation;
+  savedView: SavedViewRepresentation;
 }
 export interface SavedViewListMinimalResponse {
-  savedViews: SavedViewWithDataMinimal[];
+  savedViews: SavedViewMinimal[];
   _links: HalLinks<["self", "prev"?, "next"?]>;
 }
 
 export interface SavedViewListRepresentationResponse {
-  savedViews: SavedViewWithDataRepresentation[];
+  savedViews: SavedViewRepresentation[];
   _links: HalLinks<["self", "prev"?, "next"?]>;
 }
 

--- a/packages/saved-views-client/src/client/SavedViewsClient.ts
+++ b/packages/saved-views-client/src/client/SavedViewsClient.ts
@@ -79,7 +79,7 @@ export interface SavedViewRepresentationResponse {
   savedView: SavedViewRepresentation;
 }
 export interface SavedViewListMinimalResponse {
-  savedViews: SavedViewMinimal[];
+  savedViews: Array<Omit<SavedViewMinimal, "savedViewData">>;
   _links: HalLinks<["self", "prev"?, "next"?]>;
 }
 

--- a/packages/saved-views-client/src/index.ts
+++ b/packages/saved-views-client/src/index.ts
@@ -9,6 +9,7 @@ export * from "./models/Group.js";
 export * from "./models/Links.js";
 export * from "./models/Tag.js";
 export * from "./models/savedViews/DisplayStyles.js";
+export { isViewDataITwin3d, isViewDataITwinDrawing, isViewDataITwinSheet } from "./models/savedViews/View.js";
 export type {
   ClipPlaneProps, ClipPrimitivePlaneProps, ClipPrimitiveShapeProps, PlanesProps, SavedView, SavedViewMinimal,
   SavedViewRepresentation, ShapeProps, ViewCamera, ViewData, ViewDataITwin3d, ViewDataITwinDrawing, ViewDataITwinSheet,

--- a/packages/saved-views-client/src/index.ts
+++ b/packages/saved-views-client/src/index.ts
@@ -8,4 +8,9 @@ export * from "./models/Extension.js";
 export * from "./models/Group.js";
 export * from "./models/Links.js";
 export * from "./models/Tag.js";
-export * from "./models/savedViews/View.js";
+export * from "./models/savedViews/DisplayStyles.js";
+export type {
+  ClipPlaneProps, ClipPrimitivePlaneProps, ClipPrimitiveShapeProps, PlanesProps, SavedView, SavedViewMinimal,
+  SavedViewRepresentation, ShapeProps, ViewCamera, ViewData, ViewDataITwin3d, ViewDataITwinDrawing, ViewDataITwinSheet,
+  ViewITwin2d, ViewITwin3d, ViewITwinDrawing, ViewITwinSheet, ViewVisibilityList, ViewYawPitchRoll,
+} from "./models/savedViews/View.js";

--- a/packages/saved-views-client/src/models/savedViews/View.ts
+++ b/packages/saved-views-client/src/models/savedViews/View.ts
@@ -2,21 +2,63 @@
 * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
-import { Extension, ExtensionMin } from "../Extension.js";
-import { HalLinks } from "../Links.js";
-import { SavedViewTag } from "../Tag.js";
-import { DisplayStyle3dSettingsProps, DisplayStyleSettingsProps } from "./DisplayStyles.js";
+import type { Extension, ExtensionMin } from "../Extension.js";
+import type { HalLinks } from "../Links.js";
+import type { SavedViewTag } from "../Tag.js";
+import type { DisplayStyle3dSettingsProps, DisplayStyleSettingsProps } from "./DisplayStyles.js";
 
-/** Minimum required information saved for a Sheet saved view. */
-export interface ViewITwinSheet extends ViewITwin2d {
-  width?: number;
-  height?: number;
-  scale?: number;
-  sheetTemplate?: string;
-  sheetAttachments?: string[];
+export interface SavedViewRepresentation extends SavedView {
+  extensions?: Extension[];
 }
 
-/** Minimum required information saved for a Drawing saved view. */
+export interface SavedViewMinimal extends SavedView {
+  extensions?: ExtensionMin[];
+}
+
+export interface SavedView {
+  id: string;
+  displayName: string;
+  shared: boolean;
+  tags?: SavedViewTag[];
+  savedViewData: ViewData & { legacyView: unknown; };
+  _links: HalLinks<["image", "thumbnail", "iTwin"?, "project"?, "imodel"?, "creator"?, "group"?]>;
+}
+
+export type ViewData = ViewDataITwin3d | ViewDataITwinDrawing | ViewDataITwinSheet;
+
+export type ViewDataITwin3d = { itwin3dView: ViewITwin3d; };
+export type ViewDataITwinDrawing = { itwinDrawingView: ViewITwinDrawing; };
+export type ViewDataITwinSheet = { itwinSheetView: ViewITwinSheet; };
+
+export interface ViewITwin3d {
+  origin: [x: number, y: number, z: number];
+  extents: [x: number, y: number, z: number];
+  angles?: ViewYawPitchRoll;
+  camera?: ViewCamera;
+  models?: ViewVisibilityList;
+  displayStyle?: DisplayStyle3dSettingsProps;
+  categories?: ViewVisibilityList;
+  clipVectors?: Array<ClipPrimitivePlaneProps | ClipPrimitiveShapeProps>;
+}
+
+/** Representation of the 3d orientation of an object in space. */
+export interface ViewYawPitchRoll {
+  yaw?: number;
+  pitch?: number;
+  roll?: number;
+}
+
+export interface ViewCamera {
+  lens: number;
+  focusDist: number;
+  eye: [x: number, y: number, z: number];
+}
+
+export interface ViewVisibilityList {
+  enabled?: string[];
+  disabled?: string[];
+}
+
 export interface ViewITwinDrawing extends ViewITwin2d {
   spatialView?: string;
   displaySpatialView?: boolean;
@@ -31,22 +73,44 @@ export interface ViewITwinDrawing extends ViewITwin2d {
   ];
 }
 
-/** Minimum required information saved for a 2d saved view (Used by Sheet and Drawings). */
-export interface ViewITwin2d extends SavedViewBase {
+export interface ViewITwinSheet extends ViewITwin2d {
+  width?: number;
+  height?: number;
+  scale?: number;
+  sheetTemplate?: string;
+  sheetAttachments?: string[];
+}
+
+export interface ViewITwin2d {
   baseModelId: string;
   origin: [x: number, y: number];
   delta: [x: number, y: number];
   angle: number;
   displayStyle?: DisplayStyleSettingsProps;
+  categories?: ViewVisibilityList;
+  clipVectors?: Array<ClipPrimitivePlaneProps | ClipPrimitiveShapeProps>;
 }
 
-export interface SavedViewBase {
-  /** Origin, represented as an array of x and y coordinates. */
-  origin: [number, number] | [number, number, number];
-  /** List of categories that should be displayed or hidden on that view. */
-  categories?: ViewVisibilityList;
-  /** Array of clip vectors in the view. */
-  clipVectors?: Array<ClipPrimitivePlaneProps | ClipPrimitiveShapeProps>;
+/** A clip primitive made of a set of planes. */
+export interface ClipPrimitivePlaneProps {
+  planes: PlanesProps;
+}
+
+/** Contains a set of clip planes used to clip the view. */
+export interface PlanesProps {
+  clips: ClipPlaneProps[][];
+  invisible?: boolean;
+}
+
+/**
+ * Wire format describing a ClipPlane. If either normal or dist are omitted, defaults to a normal of Vector3d.unitZ and
+ * a distance of zero.
+ */
+export interface ClipPlaneProps {
+  normal?: [x: number, y: number, z: number];
+  distance?: number;
+  invisible?: boolean;
+  interior?: boolean;
 }
 
 /** A clip primitive made of a shape. */
@@ -66,86 +130,4 @@ export interface ShapeProps {
   zHigh?: number;
   mask?: boolean;
   invisible?: boolean;
-}
-
-
-/** A clip primitive made of a set planes. */
-export interface ClipPrimitivePlaneProps {
-  planes: PlanesProps;
-}
-
-/** Contains the set of clip planes used to clip the view. */
-export interface PlanesProps {
-  clips: ClipPlaneProps[][];
-  invisible?: boolean;
-}
-
-/**
- * Wire format describing a ClipPlane. If either normal or dist are omitted, defaults to a normal of Vector3d.unitZ and
- * a distance of zero.
- */
-export interface ClipPlaneProps {
-  normal?: [x: number, y: number, z: number];
-  distance?: number;
-  invisible?: boolean;
-  interior?: boolean;
-}
-
-export type ViewDataItwin3d = { itwin3dView: ViewITwin3d; };
-export type ViewDataITwinSheet = { itwinSheetView: ViewITwinSheet; };
-export type ViewDataITwinDrawing = { itwinDrawingView: ViewITwinDrawing; };
-
-/** Minimum Saved View structure so every application can have something to work with. */
-export type ViewData = ViewDataItwin3d | ViewDataITwinSheet | ViewDataITwinDrawing;
-
-/** Minimum saved view structure including possible legacy data. */
-export type ViewDataWithLegacy = ViewData & { legacyView: unknown; };
-
-/** Minimum required information saved for a 3D saved view. */
-export interface ViewITwin3d extends SavedViewBase {
-  origin: [x: number, y: number, z: number];
-  extents: [x: number, y: number, z: number];
-  angles?: ViewYawPitchRoll;
-  camera?: ViewCamera;
-  models?: ViewVisibilityList;
-  displayStyle?: DisplayStyle3dSettingsProps;
-}
-
-/** Representation of the 3d orientation of an object in space. */
-export interface ViewYawPitchRoll {
-  yaw?: number;
-  pitch?: number;
-  roll?: number;
-}
-
-/** Required camera information. */
-export interface ViewCamera {
-  lens: number;
-  focusDist: number;
-  eye: [x: number, y: number, z: number];
-}
-
-/** List of explicitly enabled/disabled Id64Strings, used for Categories and Models. */
-export interface ViewVisibilityList {
-  enabled?: string[];
-  disabled?: string[];
-}
-
-export interface SavedViewWithDataRepresentation extends SavedView {
-  savedViewData: ViewDataWithLegacy;
-  extensions?: Extension[];
-}
-
-export interface SavedViewWithDataMinimal extends SavedView {
-  savedViewData: ViewDataWithLegacy;
-  extensions?: ExtensionMin[];
-}
-
-
-export interface SavedView {
-  id: string;
-  displayName: string;
-  shared: boolean;
-  tags?: SavedViewTag[];
-  _links: HalLinks<["image", "thumbnail", "iTwin"?, "project"?, "imodel"?, "creator"?, "group"?]>;
 }

--- a/packages/saved-views-client/src/models/savedViews/View.ts
+++ b/packages/saved-views-client/src/models/savedViews/View.ts
@@ -27,8 +27,22 @@ export interface SavedView {
 export type ViewData = ViewDataITwin3d | ViewDataITwinDrawing | ViewDataITwinSheet;
 
 export type ViewDataITwin3d = { itwin3dView: ViewITwin3d; };
+
+export function isViewDataITwin3d(savedViewData: ViewData): savedViewData is ViewDataITwin3d {
+  return (savedViewData as ViewDataITwin3d).itwin3dView !== undefined;
+}
+
 export type ViewDataITwinDrawing = { itwinDrawingView: ViewITwinDrawing; };
+
+export function isViewDataITwinDrawing(savedViewData: ViewData): savedViewData is ViewDataITwinDrawing {
+  return (savedViewData as ViewDataITwinDrawing).itwinDrawingView !== undefined;
+}
+
 export type ViewDataITwinSheet = { itwinSheetView: ViewITwinSheet; };
+
+export function isViewDataITwinSheet(savedViewData: ViewData): savedViewData is ViewDataITwinSheet {
+  return (savedViewData as ViewDataITwinSheet).itwinSheetView !== undefined;
+}
 
 export interface ViewITwin3d {
   origin: [x: number, y: number, z: number];

--- a/packages/saved-views-react/CHANGELOG.md
+++ b/packages/saved-views-react/CHANGELOG.md
@@ -11,7 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Component CSS styles are now scoped to `itwin-svr` CSS layer
 * Add `@itwin/core-geometry` as peer dependency
 * Add `SavedViewsClient.uploadThumbnail` method
-* Add `SavedViewActions.uploadImage` method
+* Add `SavedViewActions.uploadThumbnail` method
 * `SavedViewActions.createSavedView` method now returns a promise which resolves into created Saved View id
 
 ### Minor changes

--- a/packages/saved-views-react/CHANGELOG.md
+++ b/packages/saved-views-react/CHANGELOG.md
@@ -8,7 +8,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Breaking changes
 
-* Component CSS styles are now scoped to `itwin-svr` CSS layer.
+* Component CSS styles are now scoped to `itwin-svr` CSS layer
+* Add `@itwin/core-geometry` as peer dependency
+* Add `SavedViewsClient.uploadThumbnail` method
+* Add `SavedViewActions.uploadImage` method
+* `SavedViewActions.createSavedView` method now returns a promise which resolves into created Saved View id
+
+### Minor changes
+
+* Add view capturing functions
+    * `captureSavedViewData`
+    * `captureSavedViewThumbnail`
+
 
 ## [0.1.0](https://github.com/iTwin/saved-views/tree/v0.1.0-react/packages/saved-views-react) - 2024-02-02
 

--- a/packages/saved-views-react/package.json
+++ b/packages/saved-views-react/package.json
@@ -63,6 +63,7 @@
   "peerDependencies": {
     "@itwin/core-common": "^4.0.6",
     "@itwin/core-frontend": "^4.0.6",
+    "@itwin/core-geometry": "^4.0.6",
     "react": "^17.0.0 || ^18.0.0",
     "react-dom": "^17.0.0 || ^18.0.0"
   },

--- a/packages/saved-views-react/src/SavedViewsClient/ITwinSavedViewsClient.ts
+++ b/packages/saved-views-react/src/SavedViewsClient/ITwinSavedViewsClient.ts
@@ -144,7 +144,7 @@ export class ITwinSavedViewsClient implements SavedViewsClient {
   }
 }
 
-function savedViewResponseToSavedView(response: SavedViewMinimal): SavedView {
+function savedViewResponseToSavedView(response: Omit<SavedViewMinimal, "savedViewData">): SavedView {
   return {
     id: response.id,
     displayName: response.displayName,

--- a/packages/saved-views-react/src/SavedViewsClient/ITwinSavedViewsClient.ts
+++ b/packages/saved-views-react/src/SavedViewsClient/ITwinSavedViewsClient.ts
@@ -3,7 +3,7 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 import {
-  ITwinSavedViewsClient as Client, type Group, type SavedViewWithDataMinimal, type SavedViewWithDataRepresentation,
+  ITwinSavedViewsClient as Client, type Group, type SavedViewMinimal, type SavedViewRepresentation,
   type Tag,
 } from "@itwin/saved-views-client";
 
@@ -47,7 +47,7 @@ export class ITwinSavedViewsClient implements SavedViewsClient {
     };
   }
 
-  public async getSingularSavedView(args: GetSingularSavedViewParams): Promise<SavedViewWithDataRepresentation> {
+  public async getSingularSavedView(args: GetSingularSavedViewParams): Promise<SavedViewRepresentation> {
     const response = await this.client.getSavedViewRepresentation({
       savedViewId: args.savedViewId,
       signal: args.signal,
@@ -144,7 +144,7 @@ export class ITwinSavedViewsClient implements SavedViewsClient {
   }
 }
 
-function savedViewResponseToSavedView(response: SavedViewWithDataMinimal): SavedView {
+function savedViewResponseToSavedView(response: SavedViewMinimal): SavedView {
   return {
     id: response.id,
     displayName: response.displayName,

--- a/packages/saved-views-react/src/SavedViewsClient/ITwinSavedViewsClient.ts
+++ b/packages/saved-views-react/src/SavedViewsClient/ITwinSavedViewsClient.ts
@@ -11,7 +11,7 @@ import type { SavedView, SavedViewGroup, SavedViewTag } from "../SavedView.js";
 import type {
   CreateGroupParams, CreateSavedViewParams, CreateTagParams, DeleteGroupParams, DeleteSavedViewParams, DeleteTagParams,
   GetSavedViewInfoParams, GetSingularSavedViewParams, GetThumbnailUrlParams, SavedViewInfo, SavedViewsClient,
-  UpdateGroupParams, UpdateSavedViewParams, UpdateTagParams,
+  UpdateGroupParams, UpdateSavedViewParams, UpdateTagParams, UploadThumbnailParams,
 } from "./SavedViewsClient.js";
 
 interface ITwinSavedViewsClientParams {
@@ -62,6 +62,14 @@ export class ITwinSavedViewsClient implements SavedViewsClient {
       signal: args.signal,
     });
     return response.href;
+  }
+
+  public async uploadThumbnail(args: UploadThumbnailParams): Promise<void> {
+    await this.client.updateImage({
+      savedViewId: args.savedViewId,
+      image: args.image,
+      signal: args.signal,
+    });
   }
 
   public async createSavedView(args: CreateSavedViewParams): Promise<SavedView> {

--- a/packages/saved-views-react/src/SavedViewsClient/SavedViewsClient.ts
+++ b/packages/saved-views-react/src/SavedViewsClient/SavedViewsClient.ts
@@ -18,6 +18,7 @@ export interface SavedViewsClient {
   getSavedViewInfo: (args: GetSavedViewInfoParams) => Promise<SavedViewInfo>;
   getSingularSavedView: (args: GetSingularSavedViewParams) => Promise<SavedViewRepresentation>;
   getThumbnailUrl: (args: GetThumbnailUrlParams) => Promise<string | undefined>;
+  uploadThumbnail: (args: UploadThumbnailParams) => Promise<void>;
   createSavedView: (args: CreateSavedViewParams) => Promise<SavedView>;
   updateSavedView: (args: UpdateSavedViewParams) => Promise<SavedView>;
   deleteSavedView: (args: DeleteSavedViewParams) => Promise<void>;
@@ -40,6 +41,12 @@ export interface GetSingularSavedViewParams extends CommonParams {
 
 export interface GetThumbnailUrlParams extends CommonParams {
   savedViewId: string;
+}
+
+export interface UploadThumbnailParams extends CommonParams {
+  savedViewId: string;
+  /** Image data encoded as base64 data URL. */
+  image: string;
 }
 
 export interface CreateSavedViewParams extends CommonParams {

--- a/packages/saved-views-react/src/SavedViewsClient/SavedViewsClient.ts
+++ b/packages/saved-views-react/src/SavedViewsClient/SavedViewsClient.ts
@@ -3,7 +3,7 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 import type {
-  ExtensionMin, ExtensionSavedViewCreate, SavedViewWithDataRepresentation, ViewData,
+  ExtensionMin, ExtensionSavedViewCreate, SavedViewRepresentation, ViewData,
 } from "@itwin/saved-views-client";
 
 import type { SavedView, SavedViewGroup, SavedViewTag } from "../SavedView.js";
@@ -16,7 +16,7 @@ export interface SavedViewInfo {
 
 export interface SavedViewsClient {
   getSavedViewInfo: (args: GetSavedViewInfoParams) => Promise<SavedViewInfo>;
-  getSingularSavedView: (args: GetSingularSavedViewParams) => Promise<SavedViewWithDataRepresentation>;
+  getSingularSavedView: (args: GetSingularSavedViewParams) => Promise<SavedViewRepresentation>;
   getThumbnailUrl: (args: GetThumbnailUrlParams) => Promise<string | undefined>;
   createSavedView: (args: CreateSavedViewParams) => Promise<SavedView>;
   updateSavedView: (args: UpdateSavedViewParams) => Promise<SavedView>;

--- a/packages/saved-views-react/src/api/utilities/translation/SavedViewTranslation.ts
+++ b/packages/saved-views-react/src/api/utilities/translation/SavedViewTranslation.ts
@@ -7,8 +7,8 @@ import {
   DrawingViewState, EmphasizeElements, IModelConnection, ScreenViewport, SheetViewState, SpatialViewState, ViewState,
   Viewport,
 } from "@itwin/core-frontend";
-import type {
-  Extension, SavedViewRepresentation, ViewData, ViewDataITwinDrawing, ViewDataITwinSheet, ViewDataITwin3d,
+import {
+  isViewDataITwin3d, isViewDataITwinDrawing, isViewDataITwinSheet, type Extension, type SavedViewRepresentation,
 } from "@itwin/saved-views-client";
 
 import { isDrawingSavedView, isSheetSavedView, isSpatialSavedView } from "../../clients/ISavedViewsClient.js";
@@ -24,18 +24,6 @@ enum ViewTypes {
   SheetViewDefinition,
   ViewDefinition3d,
   DrawingViewDefinition,
-}
-
-function isSavedViewItwin3d(savedViewData: ViewData): savedViewData is ViewDataITwin3d {
-  return (savedViewData as ViewDataITwin3d).itwin3dView !== undefined;
-}
-
-function isSavedViewItwinSheet(savedViewData: ViewData): savedViewData is ViewDataITwinSheet {
-  return (savedViewData as ViewDataITwinSheet).itwinSheetView !== undefined;
-}
-
-function isSavedViewItwinDrawing(savedViewData: ViewData): savedViewData is ViewDataITwinDrawing {
-  return (savedViewData as ViewDataITwinDrawing).itwinDrawingView !== undefined;
 }
 
 /**
@@ -111,7 +99,7 @@ async function translateSavedViewToLegacySavedView(
     legacySavedView = savedViewData.legacyView as any;
     // legacySavedView.id = savedView.id; // Change legacy sv id to comboId
 
-  } else if (isSavedViewItwin3d(savedViewData)) {
+  } else if (isViewDataITwin3d(savedViewData)) {
     const iModelViewData = await fetchIModelViewData(
       ViewTypes.ViewDefinition3d,
       iModelConnection,
@@ -122,7 +110,7 @@ async function translateSavedViewToLegacySavedView(
     );
     legacySavedView = actual;
 
-  } else if (isSavedViewItwinDrawing(savedViewData)) {
+  } else if (isViewDataITwinDrawing(savedViewData)) {
     const iModelViewData = await fetchIModelViewData(
       ViewTypes.DrawingViewDefinition,
       iModelConnection,
@@ -133,7 +121,7 @@ async function translateSavedViewToLegacySavedView(
     );
     legacySavedView = actual;
 
-  } else if (isSavedViewItwinSheet(savedViewData)) {
+  } else if (isViewDataITwinSheet(savedViewData)) {
     const iModelViewData = await fetchIModelViewData(
       ViewTypes.SheetViewDefinition,
       iModelConnection,

--- a/packages/saved-views-react/src/api/utilities/translation/SavedViewTranslation.ts
+++ b/packages/saved-views-react/src/api/utilities/translation/SavedViewTranslation.ts
@@ -7,10 +7,8 @@ import {
   DrawingViewState, EmphasizeElements, IModelConnection, ScreenViewport, SheetViewState, SpatialViewState, ViewState,
   Viewport,
 } from "@itwin/core-frontend";
-import {
-  Extension, SavedViewWithDataRepresentation, ViewData, ViewDataITwinDrawing, ViewDataITwinSheet, ViewDataItwin3d,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  ViewDataWithLegacy,
+import type {
+  Extension, SavedViewRepresentation, ViewData, ViewDataITwinDrawing, ViewDataITwinSheet, ViewDataITwin3d,
 } from "@itwin/saved-views-client";
 
 import { isDrawingSavedView, isSheetSavedView, isSpatialSavedView } from "../../clients/ISavedViewsClient.js";
@@ -28,23 +26,14 @@ enum ViewTypes {
   DrawingViewDefinition,
 }
 
-/**
- * Type-check for {@link ViewDataItwin3d}
- */
-function isSavedViewItwin3d(savedViewData: ViewData): savedViewData is ViewDataItwin3d {
-  return (savedViewData as ViewDataItwin3d).itwin3dView !== undefined;
+function isSavedViewItwin3d(savedViewData: ViewData): savedViewData is ViewDataITwin3d {
+  return (savedViewData as ViewDataITwin3d).itwin3dView !== undefined;
 }
 
-/**
- * Type-check for {@link ViewDataITwinSheet}
- */
 function isSavedViewItwinSheet(savedViewData: ViewData): savedViewData is ViewDataITwinSheet {
   return (savedViewData as ViewDataITwinSheet).itwinSheetView !== undefined;
 }
 
-/**
- * Type-check for {@link ViewDataITwinDrawing}
- */
 function isSavedViewItwinDrawing(savedViewData: ViewData): savedViewData is ViewDataITwinDrawing {
   return (savedViewData as ViewDataITwinDrawing).itwinDrawingView !== undefined;
 }
@@ -54,7 +43,7 @@ function isSavedViewItwinDrawing(savedViewData: ViewData): savedViewData is View
  * @param legacySavedViewResponse
  * @returns SavedViewBase legacy view data
  */
-function legacyViewFrom(legacySavedViewResponse: SavedViewWithDataRepresentation): LegacySavedViewBase {
+function legacyViewFrom(legacySavedViewResponse: SavedViewRepresentation): LegacySavedViewBase {
   return legacySavedViewResponse.savedViewData.legacyView as LegacySavedViewBase;
 }
 
@@ -62,12 +51,12 @@ function legacyViewFrom(legacySavedViewResponse: SavedViewWithDataRepresentation
  * Converts a saved view response to a saved view response that includes a legacy view.
  * @param savedViewResponse A saved view response with or without a legacy view.
  * @param iModelConnection The {@link IModelConnection} for the saved view; used to query for additional information.
- * @returns A {@link SavedViewWithDataRepresentation} that contains legacy saved view data (i.e., {@link ViewDataWithLegacy.legacyView}).
+ * @returns A {@link SavedViewRepresentation} that contains legacy saved view data.
  */
 export async function translateSavedViewResponseToLegacySavedViewResponse(
-  savedViewResponse: SavedViewWithDataRepresentation,
+  savedViewResponse: SavedViewRepresentation,
   iModelConnection: IModelConnection,
- ): Promise<SavedViewWithDataRepresentation> {
+): Promise<SavedViewRepresentation> {
   const legacySavedView = await translateSavedViewToLegacySavedView(savedViewResponse, iModelConnection);
   const legacySavedViewResponse = savedViewResponse;
   legacySavedViewResponse.savedViewData.legacyView = legacySavedView;
@@ -76,11 +65,11 @@ export async function translateSavedViewResponseToLegacySavedViewResponse(
 
 /**
  * Converts a legacy saved view (response) to an iTwin.js ViewState.
- * @param legacySavedViewResponse A saved view response that includes a legacy view (i.e., {@link ViewDataWithLegacy.legacyView}).
+ * @param legacySavedViewResponse A saved view response that includes a legacy view.
  * @param iModelConnection The {@link IModelConnection} for the saved view; used to query for additional information.
  * @returns A {@link ViewState} with the saved view applied.
  */
-export async function translateLegacySavedViewToITwinJsViewState(legacySavedViewResponse: SavedViewWithDataRepresentation, iModelConnection: IModelConnection): Promise<ViewState | undefined> {
+export async function translateLegacySavedViewToITwinJsViewState(legacySavedViewResponse: SavedViewRepresentation, iModelConnection: IModelConnection): Promise<ViewState | undefined> {
   const legacySavedView = legacyViewFrom(legacySavedViewResponse);
   const viewState = await createViewState(iModelConnection, legacySavedView);
 
@@ -94,9 +83,9 @@ export async function translateLegacySavedViewToITwinJsViewState(legacySavedView
 /**
  * Apply extension data (overrides) onto the supplied viewport. Only works with legacy-formatted extension data.
  * @param viewport The {@link ScreenViewport} used to display the saved view and iModel.
- * @param legacySavedViewResponse A saved view response that includes a legacy view (i.e., {@link ViewDataWithLegacy.legacyView}).
+ * @param legacySavedViewResponse A saved view response that includes a legacy view.
  */
-export async function applyExtensionsToViewport(viewport: ScreenViewport, legacySavedViewResponse: SavedViewWithDataRepresentation | undefined) {
+export async function applyExtensionsToViewport(viewport: ScreenViewport, legacySavedViewResponse: SavedViewRepresentation | undefined) {
   if (!legacySavedViewResponse) {
     return;
   }
@@ -110,9 +99,9 @@ export async function applyExtensionsToViewport(viewport: ScreenViewport, legacy
 * @resolves The saved views formatted as a legacy SavedViewBase.
 */
 async function translateSavedViewToLegacySavedView(
-  savedViewResponse: SavedViewWithDataRepresentation,
+  savedViewResponse: SavedViewRepresentation,
   iModelConnection: IModelConnection,
- ): Promise<LegacySavedViewBase> {
+): Promise<LegacySavedViewBase> {
   const savedViewData = savedViewResponse.savedViewData;
   // If the legacy view already exists, use that; otherwise, use extraction code to get the legacy view
   let legacySavedView: LegacySavedViewBase;

--- a/packages/saved-views-react/src/api/utilities/translation/clipVectorsLegacyExtractor.ts
+++ b/packages/saved-views-react/src/api/utilities/translation/clipVectorsLegacyExtractor.ts
@@ -1,0 +1,71 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+import type { SpatialViewDefinitionProps } from "@itwin/core-common";
+import type { ClipPrimitivePlaneProps, ClipPrimitiveShapeProps, ViewITwin3d } from "@itwin/saved-views-client";
+
+import {
+  applyExtraction, extractArray2d, extractArrayConditionally, extractBoolean, extractNumber, extractObject,
+  extractSimpleArray, simpleTypeOf,
+} from "./extractionUtilities.js";
+
+export function extractClipVectorsFromLegacy(
+  input: SpatialViewDefinitionProps,
+): Array<ClipPrimitivePlaneProps | ClipPrimitiveShapeProps> | undefined {
+  const viewDetails = input.jsonProperties?.viewDetails;
+  if (!viewDetails || !("clip" in viewDetails)) {
+    return undefined;
+  }
+
+  const output = {} as ViewITwin3d;
+  applyExtraction(viewDetails, output, clipVectorLegacyMappings);
+  return output.clipVectors;
+}
+
+const clipPlaneLegacyMappings = [
+  extractSimpleArray(simpleTypeOf("number"), "normal"),
+  extractNumber("dist", "distance"),
+  extractBoolean("invisible"),
+  extractBoolean("interior"),
+];
+
+const clipPrimitivePlaneLegacyMappings = [
+  extractObject(
+    [extractArray2d(clipPlaneLegacyMappings, "clips"), extractBoolean("invisible")],
+    "planes",
+  ),
+];
+
+const clipPrimitiveShapeLegacyMappings = [
+  extractObject(
+    [
+      extractSimpleArray(isPoint, "points"),
+      extractSimpleArray(isTransformRow, "trans", "transform"),
+      extractNumber("zlow", "zLow"),
+      extractNumber("zhigh", "zHigh"),
+      extractBoolean("mask"),
+      extractBoolean("invisible"),
+    ],
+    "shape",
+  ),
+];
+
+const clipVectorLegacyMappings = [
+  extractArrayConditionally(
+    [
+      { discriminator: "planes", mappings: clipPrimitivePlaneLegacyMappings },
+      { discriminator: "shape", mappings: clipPrimitiveShapeLegacyMappings },
+    ],
+    "clip",
+    "clipVectors",
+  ),
+];
+
+function isPoint(val: unknown): val is [number, number, number] {
+  return Array.isArray(val) && val.length === 3 && val.every((num) => typeof num === "number");
+}
+
+function isTransformRow(value: unknown): value is [number, number, number, number] {
+  return Array.isArray(value) && value.length === 4 && value.every((num) => typeof num === "number");
+}

--- a/packages/saved-views-react/src/api/utilities/translation/displayStyleExtractor.ts
+++ b/packages/saved-views-react/src/api/utilities/translation/displayStyleExtractor.ts
@@ -2,8 +2,11 @@
 * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
+import type { DisplayStyle3dProps, DisplayStyleProps } from "@itwin/core-common";
 import type { ViewState } from "@itwin/core-frontend";
-import { ViewITwin2d, ViewITwin3d } from "@itwin/saved-views-client";
+import type {
+  DisplayStyle3dSettingsProps, DisplayStyleSettingsProps, ViewITwin2d, ViewITwin3d,
+} from "@itwin/saved-views-client";
 
 import type { LegacySavedView, LegacySavedView2d } from "../SavedViewTypes.js";
 import {
@@ -574,7 +577,7 @@ const displayStyle3dMapping: ExtractionFunc<void, void>[] = [
 const displayStyle3dLegacyMapping: ExtractionFunc<void, void>[] = [
   ...displayStylesLegacyMapping,
   extractObject(environmentLegacyMappings, "environment"),
-  extractObject(ambientOcclusionMappings, "ambientOcclusion", "ao"),
+  extractObject(ambientOcclusionMappings, "ao", "ambientOcclusion"),
   extractObject(solarShadowMappings, "solarShadows"),
   extractObject(lightsMappings, "lights"),
   extractPlainTypedMap(
@@ -611,11 +614,13 @@ export const extractDisplayStyle = (data: object, viewState?: ViewState) => {
   return output;
 };
 
-/**
- * Extracts the display style 3d from a legacy view displayStyle field
- * And transforms it into our schema
- * @param data
- */
+export function extractDisplayStyle2dFromLegacy(data: DisplayStyleProps): DisplayStyleSettingsProps {
+  const styles = data.jsonProperties?.styles;
+  const output = {};
+  applyExtraction(styles, output, displayStyle3dLegacyMapping);
+  return output;
+}
+
 export const extractDisplayStyle3d = (data: object) => {
   let styles;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -634,6 +639,13 @@ export const extractDisplayStyle3d = (data: object) => {
 
   return output;
 };
+
+export function extractDisplayStyle3dFromLegacy(data: DisplayStyle3dProps): DisplayStyle3dSettingsProps {
+  const output = {} as DisplayStyle3dSettingsProps;
+  const styles = data.jsonProperties?.styles;
+  applyExtraction(styles, output, displayStyle3dLegacyMapping);
+  return output;
+}
 
 function appendAcsAndGridViewFlagsToOutput(
   drawingViewState: ViewState,

--- a/packages/saved-views-react/src/api/utilities/translation/urlConverter.ts
+++ b/packages/saved-views-react/src/api/utilities/translation/urlConverter.ts
@@ -3,7 +3,7 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 import { BaseMapLayerProps, ImageMapLayerProps } from "@itwin/core-common";
-import type { ViewData, ViewDataITwinDrawing, ViewDataITwinSheet, ViewDataItwin3d } from "@itwin/saved-views-client";
+import type { ViewData, ViewDataITwinDrawing, ViewDataITwinSheet, ViewDataITwin3d } from "@itwin/saved-views-client";
 
 /**
  * Convert url that potentially contains subtituted characters ('++and++' or '++dot++') to use restricated characters ('&' or '.')
@@ -21,7 +21,7 @@ export const convertAllLegacyUrlsToUrls = (
   convert: (url: string) => string,
 ): void => {
   const displayStyle =
-    (savedViewData as ViewDataItwin3d)?.itwin3dView.displayStyle ??
+    (savedViewData as ViewDataITwin3d)?.itwin3dView.displayStyle ??
     (savedViewData as ViewDataITwinDrawing)?.itwinDrawingView.displayStyle ??
     (savedViewData as ViewDataITwinSheet)?.itwinSheetView.displayStyle;
   if (displayStyle === undefined) {

--- a/packages/saved-views-react/src/api/utilities/translation/viewExtractorSavedViewToLegacySavedView.ts
+++ b/packages/saved-views-react/src/api/utilities/translation/viewExtractorSavedViewToLegacySavedView.ts
@@ -5,8 +5,8 @@
 import type { Id64Array } from "@itwin/core-bentley";
 import { SheetViewState, type DrawingViewState, type SpatialViewState } from "@itwin/core-frontend";
 import type {
-  SavedViewBase, SavedViewTag, SavedViewWithDataRepresentation, ViewDataITwinDrawing, ViewDataITwinSheet,
-  ViewDataItwin3d, ViewITwin3d,
+  SavedViewRepresentation, SavedViewTag, ViewDataITwinDrawing, ViewDataITwinSheet, ViewDataITwin3d, ViewITwin2d,
+  ViewITwin3d,
 } from "@itwin/saved-views-client";
 
 import type { LegacySavedView, LegacySavedView2d, LegacyTag } from "../SavedViewTypes.js";
@@ -47,7 +47,7 @@ const extractTags = (creator: string, tags?: SavedViewTag[]) => {
  * @returns SavedView2d
  */
 export function savedViewItwinDrawingToLegacyDrawingView(
-  savedViewRsp: SavedViewWithDataRepresentation,
+  savedViewRsp: SavedViewRepresentation,
   seedDrawingViewState: DrawingViewState,
 ): LegacySavedView2d {
   convertAllLegacyUrlsToUrls(savedViewRsp.savedViewData, urlToLegacyUrl);
@@ -127,7 +127,7 @@ export function savedViewItwinDrawingToLegacyDrawingView(
  * @returns SavedView2d
  */
 export function savedViewItwinSheetToLegacySheetSavedView(
-  savedViewRsp: SavedViewWithDataRepresentation,
+  savedViewRsp: SavedViewRepresentation,
   seedSheetViewState: SheetViewState,
 ): LegacySavedView2d {
   convertAllLegacyUrlsToUrls(savedViewRsp.savedViewData, urlToLegacyUrl);
@@ -217,12 +217,12 @@ export function savedViewItwinSheetToLegacySheetSavedView(
  * @returns SavedView
  */
 export function savedViewITwin3dToLegacy3dSavedView(
-  savedViewRsp: SavedViewWithDataRepresentation,
+  savedViewRsp: SavedViewRepresentation,
   seedSpatialViewState: SpatialViewState,
 ): LegacySavedView {
   convertAllLegacyUrlsToUrls(savedViewRsp.savedViewData, urlToLegacyUrl);
   const modelSelector = seedSpatialViewState.modelSelector;
-  const itwin3dView = (savedViewRsp.savedViewData as ViewDataItwin3d).itwin3dView;
+  const itwin3dView = (savedViewRsp.savedViewData as ViewDataITwin3d).itwin3dView;
   const legacyView: LegacySavedView = {
     id: savedViewRsp.id,
     is2d: false,
@@ -277,7 +277,7 @@ export function savedViewITwin3dToLegacy3dSavedView(
       code: seedSpatialViewState.displayStyle.code,
       model: seedSpatialViewState.displayStyle.model,
       jsonProperties: {
-        styles: extractDisplayStyle3d((savedViewRsp.savedViewData as ViewDataItwin3d).itwin3dView),
+        styles: extractDisplayStyle3d((savedViewRsp.savedViewData as ViewDataITwin3d).itwin3dView),
       },
     },
   };
@@ -286,16 +286,11 @@ export function savedViewITwin3dToLegacy3dSavedView(
   return legacyView;
 }
 
-/**
- * append Hidden Categories Or Models To Legacy Saved View
- * @param iTwinView new schema
- * @param legacyView
- * @returns iModelViewData
- */
+/** Append Hidden Categories Or Models To Legacy Saved View. */
 function appendHiddenCategoriesToLegacyView(
-  iTwinView: SavedViewBase,
+  iTwinView: ViewITwin2d | ViewITwin3d,
   legacyView: LegacySavedView | LegacySavedView2d,
-) {
+): void {
   if (iTwinView.categories && iTwinView.categories.disabled) {
     legacyView.hiddenCategories = iTwinView.categories.disabled as Id64Array;
   }
@@ -322,7 +317,7 @@ function appendHiddenModelsTo3dLegacySavedView(
  * @returns SavedViewWithData
  */
 export const cleanLegacyViewModelSelectorPropsModels = (
-  savedView: SavedViewWithDataRepresentation,
+  savedView: SavedViewRepresentation,
 ) => {
   if ((savedView.savedViewData.legacyView as LegacySavedView)?.modelSelectorProps) {
     const savedViewCopy = structuredClone(savedView);

--- a/packages/saved-views-react/src/captureSavedViewData.ts
+++ b/packages/saved-views-react/src/captureSavedViewData.ts
@@ -1,0 +1,217 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+import { Id64Array } from "@itwin/core-bentley";
+import { QueryRowFormat, type SpatialViewDefinitionProps } from "@itwin/core-common";
+import {
+  type DrawingViewState, type IModelConnection, type SheetViewState, type SpatialViewState, type Viewport,
+} from "@itwin/core-frontend";
+import { type AngleProps, type XYProps, type XYZProps, type YawPitchRollProps } from "@itwin/core-geometry";
+import {
+  isViewDataITwin3d, type ViewData, type ViewDataITwin3d, type ViewDataITwinDrawing, type ViewDataITwinSheet,
+  type ViewITwinDrawing, type ViewYawPitchRoll,
+} from "@itwin/saved-views-client";
+
+import { extractClipVectorsFromLegacy } from "./api/utilities/translation/clipVectorsLegacyExtractor.js";
+import {
+  extractDisplayStyle2dFromLegacy, extractDisplayStyle3dFromLegacy,
+} from "./api/utilities/translation/displayStyleExtractor.js";
+
+interface SavedViewFlags {
+  supportHiddenModelsAndCategories: boolean;
+  want2dViews: boolean;
+}
+
+export async function captureSavedViewData(vp: Viewport, flags: SavedViewFlags): Promise<ViewData> {
+  const hiddenCategoriesPromise = flags.supportHiddenModelsAndCategories ? getHiddenCategories(vp) : undefined;
+
+  let savedViewData: ViewData;
+  if (vp.view.isSpatialView()) {
+    const [hiddenCategories, hiddenModels] = await Promise.all([
+      hiddenCategoriesPromise,
+      flags.supportHiddenModelsAndCategories ? getHiddenModels(vp) : undefined,
+    ]);
+    savedViewData = createSpatialSavedViewObject(vp, hiddenCategories, hiddenModels);
+  } else if (vp.view.isDrawingView()) {
+    savedViewData = createDrawingSavedViewObject(vp, await hiddenCategoriesPromise);
+  } else {
+    savedViewData = createSheetSavedViewObject(vp, await hiddenCategoriesPromise);
+  }
+
+  if (!isViewDataITwin3d(savedViewData) && !flags.want2dViews) {
+    throw new Error("No support for 2D views yet");
+  }
+
+  return savedViewData;
+}
+
+function createSpatialSavedViewObject(
+  vp: Viewport,
+  hiddenCategories: Id64Array | undefined,
+  hiddenModels: Id64Array | undefined,
+): ViewDataITwin3d {
+  const viewState = vp.view as SpatialViewState;
+
+  const displayStyleProps = viewState.displayStyle.toJSON();
+
+  // Clear the timePoint if no schedule script is available on the viewState
+  if (
+    viewState.is3d() && displayStyleProps.jsonProperties?.styles?.timePoint && !viewState.displayStyle.scheduleScript
+  ) {
+    displayStyleProps.jsonProperties.styles.timePoint = undefined;
+  }
+
+  // Omit the schedule script - may cause excessively large JSON.
+  if (displayStyleProps.jsonProperties?.styles?.scheduleScript) {
+    displayStyleProps.jsonProperties.styles.scheduleScript = undefined;
+  }
+
+  const viewDefinitionProps = viewState.toJSON() as SpatialViewDefinitionProps;
+
+  return {
+    itwin3dView: {
+      origin: toArrayVector3d(viewDefinitionProps.origin),
+      extents: toArrayVector3d(viewDefinitionProps.extents),
+      angles: viewDefinitionProps.angles && toYawPitchRoll(viewDefinitionProps.angles),
+      camera: viewDefinitionProps.cameraOn ? {
+        lens: toDegrees(viewDefinitionProps.camera.lens) ?? 0,
+        focusDist: viewDefinitionProps.camera.focusDist,
+        eye: toArrayVector3d(viewDefinitionProps.camera.eye),
+      } : undefined,
+      categories: {
+        enabled: viewState.categorySelector.toJSON().categories,
+        disabled: hiddenCategories,
+      },
+      models: {
+        enabled: viewState.modelSelector.toJSON().models,
+        disabled: hiddenModels,
+      },
+      displayStyle: extractDisplayStyle3dFromLegacy(displayStyleProps),
+      clipVectors: extractClipVectorsFromLegacy(viewDefinitionProps),
+    },
+  };
+}
+
+function toArrayVector3d(xyzProps: XYZProps): [number, number, number] {
+  if (Array.isArray(xyzProps)) {
+    return [xyzProps[0] ?? 0, xyzProps[1] ?? 0, xyzProps[2] ?? 0];
+  }
+
+  return [xyzProps.x ?? 0, xyzProps.y ?? 0, xyzProps.z ?? 0];
+}
+
+function toYawPitchRoll(angles: YawPitchRollProps): ViewYawPitchRoll {
+  return {
+    yaw: angles.yaw !== undefined ? toDegrees(angles.yaw) : undefined,
+    pitch: angles.pitch !== undefined ? toDegrees(angles.pitch) : undefined,
+    roll: angles.roll !== undefined ? toDegrees(angles.roll) : undefined,
+  };
+}
+
+function createDrawingSavedViewObject(vp: Viewport, hiddenCategories: Id64Array | undefined): ViewDataITwinDrawing {
+  const viewState = vp.view as DrawingViewState;
+  const viewDefinitionProps = viewState.toJSON();
+
+  return {
+    itwinDrawingView: {
+      modelExtents: {} as ViewITwinDrawing["modelExtents"],
+      baseModelId: viewDefinitionProps.baseModelId,
+      origin: toArrayVector2d(viewDefinitionProps.origin),
+      delta: toArrayVector2d(viewDefinitionProps.delta),
+      angle: toDegrees(viewDefinitionProps.angle) ?? 0,
+      displayStyle: extractDisplayStyle2dFromLegacy(viewState.displayStyle.toJSON()),
+      categories: {
+        enabled: viewState.categorySelector.toJSON().categories,
+        disabled: hiddenCategories,
+      },
+    },
+  };
+}
+
+function createSheetSavedViewObject(vp: Viewport, hiddenCategories: Id64Array | undefined): ViewDataITwinSheet {
+  const viewState = vp.view as SheetViewState;
+  const viewDefinitionProps = viewState.toJSON();
+
+  return {
+    itwinSheetView: {
+      baseModelId: viewDefinitionProps.baseModelId,
+      origin: toArrayVector2d(viewDefinitionProps.origin),
+      delta: toArrayVector2d(viewDefinitionProps.delta),
+      angle: toDegrees(viewDefinitionProps.angle) ?? 0,
+      displayStyle: extractDisplayStyle2dFromLegacy(viewState.displayStyle.toJSON()),
+      categories: {
+        enabled: viewState.categorySelector.toJSON().categories,
+        disabled: hiddenCategories,
+      },
+      width: viewState.sheetSize.x,
+      height: viewState.sheetSize.y,
+      sheetAttachments: viewState.attachmentIds,
+    },
+  };
+}
+
+function toArrayVector2d(xyzProps: XYProps): [number, number] {
+  if (Array.isArray(xyzProps)) {
+    return [xyzProps[0] ?? 0, xyzProps[1] ?? 0];
+  }
+
+  return [xyzProps.x ?? 0, xyzProps.y ?? 0];
+}
+
+
+function toDegrees(angle: AngleProps): number | undefined {
+  if (typeof angle === "number") {
+    return angle;
+  }
+
+  if ("degrees" in angle) {
+    return angle.degrees;
+  }
+
+  if ("radians" in angle) {
+    return angle.radians * (180 / Math.PI);
+  }
+
+  return undefined;
+}
+
+async function getHiddenModels(vp: Viewport): Promise<Id64Array> {
+  const allModels = await getAllModels(vp.iModel);
+  const visibleModels = new Set((vp.view as SpatialViewState).modelSelector.toJSON().models);
+  return allModels.map(({ id }) => id).filter((model) => !visibleModels.has(model));
+}
+
+async function getAllModels(iModel: IModelConnection): Promise<Array<{ id: string; }>> {
+  // Note: IsNotSpatiallyLocated was introduced in a later version of the BisCore ECSchema. If the iModel has an earlier
+  // version, the statement will throw because the property does not exist. If the iModel was created from an earlier
+  // version and later upgraded to a newer version, the property may be NULL for models created prior to the upgrade.
+  try {
+    return await executeQuery(
+      iModel,
+      "SELECT ECInstanceId FROM Bis.GeometricModel3D WHERE IsPrivate = false AND IsTemplate = false AND (IsNotSpatiallyLocated IS NULL OR IsNotSpatiallyLocated = false)",
+    );
+  } catch {
+    return executeQuery(
+      iModel,
+      "SELECT ECInstanceId FROM Bis.GeometricModel3D WHERE IsPrivate = false AND IsTemplate = false",
+    );
+  }
+}
+
+async function getHiddenCategories(vp: Viewport): Promise<Id64Array> {
+  const visibleCategories = new Set(vp.view.categorySelector.toJSON().categories);
+  const allCategories = await getAllCategories(vp.iModel);
+  return allCategories.map(({ id }) => id).filter((category) => !visibleCategories.has(category));
+}
+
+async function getAllCategories(iModel: IModelConnection): Promise<Array<{ id: string; }>> {
+  return executeQuery(
+    iModel,
+    "SELECT DISTINCT Category.Id AS id FROM BisCore.GeometricElement3d WHERE Category.Id IN (SELECT ECInstanceId FROM BisCore.SpatialCategory)",
+  );
+}
+
+async function executeQuery(iModel: IModelConnection, query: string): Promise<Array<{ id: string; }>> {
+  return iModel.createQueryReader(query, undefined, { rowFormat: QueryRowFormat.UseJsPropertyNames }).toArray();
+}

--- a/packages/saved-views-react/src/captureSavedViewThumbnail.ts
+++ b/packages/saved-views-react/src/captureSavedViewThumbnail.ts
@@ -1,0 +1,35 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+import type { ImageBuffer } from "@itwin/core-common";
+import { getCenteredViewRect, imageBufferToCanvas, type Viewport } from "@itwin/core-frontend";
+import { Point2d } from "@itwin/core-geometry";
+
+/** Generates Saved View thumbnail based on what is currently visible in the {@linkcode viewport}. */
+export function captureSavedViewThumbnail(viewport: Viewport, width = 280, height = 200): string | undefined {
+  const thumbnail = getThumbnail(viewport, width, height);
+  if (!thumbnail) {
+    return undefined;
+  }
+
+  const canvas = imageBufferToCanvas(thumbnail);
+  return canvas?.toDataURL("image/png", 1.0);
+}
+
+function getThumbnail(vp: Viewport, width: number, height: number): ImageBuffer | undefined {
+  const size = new Point2d(width, height);
+
+  // Passing in vp.target.viewRect instead of vp.viewRect because currently vp.viewRect is not updated correctly in some
+  // cases when a new dialog is created. The bottom property would be 2px higher than the renderRect in readImageBuffer
+  // which caused the method to return undefined. vp.target.viewRect allows us to have the correct dimensions when
+  // creating the thumbnail.
+  const thumbnail = vp.readImageBuffer({ rect: getCenteredViewRect(vp.target.viewRect), size });
+  if (thumbnail) {
+    return thumbnail;
+  }
+
+  // Since using vp.target.viewRect while creating thumbnail returns undefined for some, we switch back to using
+  // vp.viewRect
+  return vp.readImageBuffer({ rect: getCenteredViewRect(vp.viewRect), size });
+}

--- a/packages/saved-views-react/src/index.ts
+++ b/packages/saved-views-react/src/index.ts
@@ -12,5 +12,7 @@ export type { SavedViewInfo, SavedViewsClient } from "./SavedViewsClient/SavedVi
 export { SavedViewsContextProvider, type SavedViewsContext } from "./SavedViewsContext.js";
 export { StickyExpandableBlock } from "./StickyExpandableBlock/StickyExpandableBlock.js";
 export { TileGrid } from "./TileGrid/TileGrid.js";
+export { captureSavedViewData } from "./captureSavedViewData.js";
+export { captureSavedViewThumbnail } from "./captureSavedViewThumbnail.js";
 export { defaultLocalization, type LocalizationStrings } from "./localization.js";
 export { useSavedViews, type SavedViewActions } from "./useSavedViews.js";

--- a/packages/test-app-frontend/src/App/ITwinJsApp/ITwinJsApp.tsx
+++ b/packages/test-app-frontend/src/App/ITwinJsApp/ITwinJsApp.tsx
@@ -8,7 +8,7 @@ import {
   type AuthorizationClient,
 } from "@itwin/core-common";
 import {
-  CheckpointConnection, IModelApp, IModelConnection, ScreenViewport, ViewCreator3d, ViewState,
+  CheckpointConnection, IModelApp, IModelConnection, ScreenViewport, ViewCreator3d, ViewState, Viewport,
 } from "@itwin/core-frontend";
 import { ITwinLocalization } from "@itwin/core-i18n";
 import { UiCore } from "@itwin/core-react";
@@ -17,7 +17,7 @@ import { FrontendIModelsAccess } from "@itwin/imodels-access-frontend";
 import { IModelsClient } from "@itwin/imodels-client-management";
 import { PageLayout } from "@itwin/itwinui-layouts-react";
 import { useToaster } from "@itwin/itwinui-react";
-import { SavedViewWithDataRepresentation } from "@itwin/saved-views-client";
+import { SavedViewRepresentation } from "@itwin/saved-views-client";
 import { applyExtensionsToViewport } from "@itwin/saved-views-react/experimental";
 import { useEffect, useRef, useState, type ReactElement } from "react";
 
@@ -74,12 +74,14 @@ export function ITwinJsApp(props: ITwinJsAppProps): ReactElement | null {
   );
 
   const viewportRef = useRef<ScreenViewport>();
-  const handleSavedViewSelect = (savedView: SavedViewWithDataRepresentation, viewState: ViewState) => {
+  const handleSavedViewSelect = (savedView: SavedViewRepresentation, viewState: ViewState) => {
     setViewState(viewState);
     if (viewportRef.current) {
       applyExtensionsToViewport(viewportRef.current, savedView);
     }
   };
+
+  const [viewport, setViewport] = useState<Viewport>();
 
   if (loadingState === "rendering-imodel") {
     return <LoadingScreen>Opening View...</LoadingScreen>;
@@ -103,14 +105,18 @@ export function ITwinJsApp(props: ITwinJsAppProps): ReactElement | null {
         <ViewportComponent
           imodel={iModel}
           viewState={viewState}
-          viewportRef={(v) => viewportRef.current = v}
+          viewportRef={(v) => (setViewport(v), viewportRef.current = v)}
         />
-        <SavedViewsWidget
-          iTwinId={props.iTwinId}
-          iModelId={props.iModelId}
-          iModel={iModel}
-          onSavedViewSelect={handleSavedViewSelect}
-        />
+        {
+          viewport &&
+          <SavedViewsWidget
+            iTwinId={props.iTwinId}
+            iModelId={props.iModelId}
+            iModel={iModel}
+            onSavedViewSelect={handleSavedViewSelect}
+            viewport={viewport}
+          />
+        }
       </Overlap>
     </PageLayout.Content>
   );

--- a/packages/test-app-frontend/src/App/ITwinJsApp/SavedViewsWidget.tsx
+++ b/packages/test-app-frontend/src/App/ITwinJsApp/SavedViewsWidget.tsx
@@ -4,7 +4,7 @@
 *--------------------------------------------------------------------------------------------*/
 import { IModelConnection, type ViewState } from "@itwin/core-frontend";
 import { Button, useToaster } from "@itwin/itwinui-react";
-import type { SavedViewWithDataRepresentation } from "@itwin/saved-views-client";
+import type { SavedViewRepresentation } from "@itwin/saved-views-client";
 import { ITwinSavedViewsClient, useSavedViews } from "@itwin/saved-views-react";
 import {
   SavedViewsFolderWidget, createSavedViewOptions, translateLegacySavedViewToITwinJsViewState,
@@ -20,7 +20,7 @@ interface SavedViewsWidgetProps {
   iTwinId: string;
   iModelId: string;
   iModel: IModelConnection;
-  onSavedViewSelect: (savedView: SavedViewWithDataRepresentation, viewState: ViewState) => void;
+  onSavedViewSelect: (savedView: SavedViewRepresentation, viewState: ViewState) => void;
 }
 
 export function SavedViewsWidget(props: SavedViewsWidgetProps): ReactElement {

--- a/packages/test-app-frontend/src/App/ITwinJsApp/SavedViewsWidget.tsx
+++ b/packages/test-app-frontend/src/App/ITwinJsApp/SavedViewsWidget.tsx
@@ -2,12 +2,12 @@
 * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
-import { IModelConnection, type ViewState } from "@itwin/core-frontend";
+import { IModelConnection, Viewport, type ViewState } from "@itwin/core-frontend";
 import { Button, useToaster } from "@itwin/itwinui-react";
 import type { SavedViewRepresentation } from "@itwin/saved-views-client";
-import { ITwinSavedViewsClient, useSavedViews } from "@itwin/saved-views-react";
+import { captureSavedViewData, captureSavedViewThumbnail, ITwinSavedViewsClient, useSavedViews } from "@itwin/saved-views-react";
 import {
-  SavedViewsFolderWidget, createSavedViewOptions, translateLegacySavedViewToITwinJsViewState,
+  createSavedViewOptions, SavedViewsFolderWidget, translateLegacySavedViewToITwinJsViewState,
   translateSavedViewResponseToLegacySavedViewResponse,
 } from "@itwin/saved-views-react/experimental";
 import { ReactElement, useMemo, useState } from "react";
@@ -20,6 +20,7 @@ interface SavedViewsWidgetProps {
   iTwinId: string;
   iModelId: string;
   iModel: IModelConnection;
+  viewport: Viewport;
   onSavedViewSelect: (savedView: SavedViewRepresentation, viewState: ViewState) => void;
 }
 
@@ -72,20 +73,17 @@ export function SavedViewsWidget(props: SavedViewsWidgetProps): ReactElement {
     return <LoadingScreen>Loading saved views...</LoadingScreen>;
   }
 
-  const handleCreateView = () => savedViews.actions.createSavedView(
-    "0 Saved View Name",
-    {
-      itwin3dView: {
-        origin: [0.0, 0.0, 0.0],
-        extents: [100.0, 100.0, 100.0],
-        angles: {
-          yaw: 90.0,
-          pitch: 90.0,
-          roll: 90.0,
-        },
-      },
-    },
-  );
+  const handleCreateView = async () => {
+    const savedViewData = await captureSavedViewData(
+      props.viewport,
+      { supportHiddenModelsAndCategories: true, want2dViews: true },
+    );
+    const savedViewId = await savedViews.actions.createSavedView("0 Saved View Name", savedViewData);
+    const thumbnail = captureSavedViewThumbnail(props.viewport);
+    if (thumbnail) {
+      savedViews.actions.uploadThumbnail(savedViewId, thumbnail);
+    }
+  };
 
   const groups = [...savedViews.groups.values()];
   const tags = [...savedViews.tags.values()];


### PR DESCRIPTION
## @itwin/saved-views-client

### Breaking changes

* Remove `SavedViewBase` type
* Omit `savedViewData` property from `SavedViewListMinimalResponse` type
* Rename types
    * `SavedViewWithDataMinimal` -> `SavedViewMinimal`
    * `SavedViewWithDataRepresentation` -> `SavedViewRepresentation`
    * `ViewDataItwin3d` -> `ViewDataITwin3d`

### Minor changes

* Add new type guards to discern `ViewData` union members
    * `isViewDataITwin3d`
    * `isViewDataITwinDrawing`
    * `isViewDataITwinSheet`

### Fixes

* Fix being unable to send Saved View to iTwin Saved Views service when `savedViewData` contains URL fields

## @itwin/saved-views-react

### Breaking changes

* Add `@itwin/core-geometry` as peer dependency
* Add `SavedViewsClient.uploadThumbnail` method
* Add `SavedViewActions.uploadThumbnail` method
* `SavedViewActions.createSavedView` method now returns a promise which resolves into created Saved View id

### Minor changes

* Add view capturing functions
    * `captureSavedViewData`
    * `captureSavedViewThumbnail`

## test-app-frontend

* Capture and upload Saved View data
* Capture and upload Saved View thumbnail