### PR TITLE
Define `types` field in package.json

### DIFF
--- a/packages/saved-views-client/CHANGELOG.md
+++ b/packages/saved-views-client/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
     * `isViewDataITwin3d`
     * `isViewDataITwinDrawing`
     * `isViewDataITwinSheet`
+* `package.json`: Define `types` field to help ES module users that have badly configured `tsconfig.json`
 
 ### Fixes
 

--- a/packages/saved-views-client/package.json
+++ b/packages/saved-views-client/package.json
@@ -13,6 +13,7 @@
     "url": "https://www.bentley.com"
   },
   "type": "module",
+  "types": "./lib/index.d.ts",
   "exports": {
     ".": {
       "types": "./lib/index.d.ts",

--- a/packages/saved-views-react/CHANGELOG.md
+++ b/packages/saved-views-react/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Add view capturing functions
     * `captureSavedViewData`
     * `captureSavedViewThumbnail`
+* `package.json`: Define `types` field to help ES module users that have badly configured `tsconfig.json`
 
 
 ## [0.1.0](https://github.com/iTwin/saved-views/tree/v0.1.0-react/packages/saved-views-react) - 2024-02-02

--- a/packages/saved-views-react/package.json
+++ b/packages/saved-views-react/package.json
@@ -13,6 +13,7 @@
     "url": "https://www.bentley.com"
   },
   "type": "module",
+  "types": "./lib/index.d.ts",
   "exports": {
     ".": {
       "types": "./lib/index.d.ts",


### PR DESCRIPTION
Define `types` field in `package.json` files to help ES module users that have badly configured `tsconfig.json` have fewer issues importing these packages.