### PR TITLE
Fix getAllSavedViewsMinimal query

### DIFF
--- a/packages/saved-views-client/src/client/ITwinSavedViewsClient.test.ts
+++ b/packages/saved-views-client/src/client/ITwinSavedViewsClient.test.ts
@@ -95,7 +95,7 @@ describe("ITwinSavedViewsClient", () => {
     });
 
     verifyFetch({
-      url: "https://api.bentley.com/savedviews?iTwinId=test_itwinid&iModelId=test_imodelid&groupId=test_groupid&$top=test_top&$skip=test_skip",
+      url: "https://api.bentley.com/savedviews/?iTwinId=test_itwinid&iModelId=test_imodelid&groupId=test_groupid&$top=test_top&$skip=test_skip",
       method: "GET",
       headers: { Prefer: PreferOptions.Representation },
     });

--- a/packages/saved-views-client/src/client/ITwinSavedViewsClient.test.ts
+++ b/packages/saved-views-client/src/client/ITwinSavedViewsClient.test.ts
@@ -67,6 +67,21 @@ describe("ITwinSavedViewsClient", () => {
     });
   });
 
+  it("getAllSavedViewsMinimal | groupId only", async () => {
+    fetch.mockImplementation(() => createSuccessfulResponse({}));
+
+    const client = new ITwinSavedViewsClient({ getAccessToken });
+    await client.getAllSavedViewsMinimal({
+      groupId: "test_groupid",
+    });
+
+    verifyFetch({
+      url: "https://api.bentley.com/savedviews/?groupId=test_groupid",
+      method: "GET",
+      headers: { Prefer: PreferOptions.Minimal },
+    });
+  });
+
   it("getAllSavedViewsRepresentation", async () => {
     fetch.mockImplementation(() => createSuccessfulResponse({ savedViews: [] }));
 

--- a/packages/saved-views-client/src/client/ITwinSavedViewsClient.ts
+++ b/packages/saved-views-client/src/client/ITwinSavedViewsClient.ts
@@ -104,7 +104,7 @@ export class ITwinSavedViewsClient implements SavedViewsClient {
     const skip = args.skip && `$skip=${args.skip}`;
     const query = [iTwinId, iModelId, groupId, top, skip].filter((param) => param).join("&");
     const response = await this.queryITwinApi({
-      url: `${this.baseUrl}?${query}`,
+      url: `${this.baseUrl}/?${query}`,
       method: "GET",
       headers: {
         Prefer: PreferOptions.Representation,

--- a/packages/saved-views-client/src/client/ITwinSavedViewsClient.ts
+++ b/packages/saved-views-client/src/client/ITwinSavedViewsClient.ts
@@ -80,12 +80,14 @@ export class ITwinSavedViewsClient implements SavedViewsClient {
   }
 
   async getAllSavedViewsMinimal(args: GetSavedViewsParams): Promise<SavedViewListMinimalResponse> {
-    const iModelId = args.iModelId ? `&iModelId=${args.iModelId}` : "";
-    const groupId = args.groupId ? `&groupId=${args.groupId}` : "";
-    const top = args.top ? `&$top=${args.top}` : "";
-    const skip = args.skip ? `&$skip=${args.skip}` : "";
+    const iTwinId = args.iTwinId && `iTwinId=${args.iTwinId}`;
+    const iModelId = args.iModelId && `iModelId=${args.iModelId}`;
+    const groupId = args.groupId && `groupId=${args.groupId}`;
+    const top = args.top && `$top=${args.top}`;
+    const skip = args.skip && `$skip=${args.skip}`;
+    const query = [iTwinId, iModelId, groupId, top, skip].filter((param) => param).join("&");
     return this.queryITwinApi({
-      url: `${this.baseUrl}/?iTwinId=${args.iTwinId}${iModelId}${groupId}${top}${skip}`,
+      url: `${this.baseUrl}/?${query}`,
       method: "GET",
       headers: {
         Prefer: PreferOptions.Minimal,


### PR DESCRIPTION
Don't always add iTwin as a parameter to the request. This fix was made to `getAllSavedViewsRepresentation` a while ago but not made to the minimal version.

I also added one test for this that makes a minimal request without an iTwin id (which is how I found this bug in the first place).