### PR TITLE
Avoid mutating result of getSavedViewInfo

### DIFF
--- a/packages/saved-views-react/CHANGELOG.md
+++ b/packages/saved-views-react/CHANGELOG.md
@@ -28,6 +28,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 * `SavedViewTile`: Fix context menu button not appearing when `options` prop receives a function with zero parameters
 * Fix text overflow issues in `SavedViewTile` and `StickyExpandableBlock` components by truncating titles with ellipses
+* Fix an issue with `useSavedViews` failing to load Saved View thumbnails when a cached data source is used
 
 ### Dependencies
 

--- a/packages/saved-views-react/src/useSavedViews.tsx
+++ b/packages/saved-views-react/src/useSavedViews.tsx
@@ -151,13 +151,14 @@ export function useSavedViews(args: UseSavedViewsParams): UseSavedViewsResult | 
           }
 
           setState({
-            savedViews: new Map(result.savedViews.map((savedView) => {
-              if (savedView.thumbnail === undefined) {
-                savedView.thumbnail = <ThumbnailPlaceholder savedViewId={savedView.id} observer={observer} />;
-              }
-
-              return [savedView.id, savedView];
-            })),
+            savedViews: new Map(result.savedViews.map((savedView) => [
+              savedView.id,
+              {
+                ...savedView,
+                thumbnail: savedView.thumbnail
+                  ?? <ThumbnailPlaceholder savedViewId={savedView.id} observer={observer} />,
+              },
+            ])),
             groups: new Map(result.groups.map((group) => [group.id, group])),
             tags: new Map(result.tags.map((tag) => [tag.id, tag])),
             thumbnails: new Map(),


### PR DESCRIPTION
Assigning a placeholder thumbnail to result of `getSavedViewInfo` runs a risk of later misidentifying which saved views need to have their thumbnails loaded if the result set is cached and returned again.