### PR TITLE
Add creation and last modified date strings to SavedView types

### DIFF
--- a/packages/saved-views-client/CHANGELOG.md
+++ b/packages/saved-views-client/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased](https://github.com/iTwin/saved-views/tree/HEAD/packages/saved-views-client)
 
+### Minor changes
+
+* Add `creationTime` and `lastModified` properties to `SavedView` type
+
 ## [0.2.2](https://github.com/iTwin/saved-views/tree/v0.2.2-client/packages/saved-views-client) - 2024-05-09
 
 ### Minor changes

--- a/packages/saved-views-client/src/models/savedViews/View.ts
+++ b/packages/saved-views-client/src/models/savedViews/View.ts
@@ -19,7 +19,9 @@ export interface SavedView {
   id: string;
   displayName: string;
   shared: boolean;
+  /** Time the saved view was created as an ISO8601 string, `"YYYY-MM-DDTHH:mm:ss.sssZ"` */
   creationTime: string;
+  /** Time the saved view was last modified as an ISO8601 string, `"YYYY-MM-DDTHH:mm:ss.sssZ"` */
   lastModified: string;
   tags?: SavedViewTag[];
   savedViewData: ViewData & { legacyView: unknown; };

--- a/packages/saved-views-client/src/models/savedViews/View.ts
+++ b/packages/saved-views-client/src/models/savedViews/View.ts
@@ -19,8 +19,8 @@ export interface SavedView {
   id: string;
   displayName: string;
   shared: boolean;
-  creationTime: string,
-  lastModified: string,
+  creationTime: string;
+  lastModified: string;
   tags?: SavedViewTag[];
   savedViewData: ViewData & { legacyView: unknown; };
   _links: HalLinks<["image", "thumbnail", "iTwin"?, "project"?, "imodel"?, "creator"?, "group"?]>;

--- a/packages/saved-views-client/src/models/savedViews/View.ts
+++ b/packages/saved-views-client/src/models/savedViews/View.ts
@@ -19,6 +19,8 @@ export interface SavedView {
   id: string;
   displayName: string;
   shared: boolean;
+  creationTime: string,
+  lastModified: string,
   tags?: SavedViewTag[];
   savedViewData: ViewData & { legacyView: unknown; };
   _links: HalLinks<["image", "thumbnail", "iTwin"?, "project"?, "imodel"?, "creator"?, "group"?]>;


### PR DESCRIPTION
Adding `creationTime` and `lastModified`  properties to the `SavedView` interface. These properties are present on all views (even those created before the change) since we've migrated prod databases.

Note: `creationTime` and `lastModified` are sent as ISO strings from the Saved Views API. Keeping these properties as strings and not converting to Date objects is consistent with the [itwins-client](https://github.com/iTwin/itwins-client/blob/e26267e4dda43b4ca32b7879f634a749df966a2b/src/iTwinsAccessProps.ts#L78).