### PR TITLE
Fix view failing to apply when there is no default view

### DIFF
--- a/packages/saved-views-react/src/api/utilities/translation/SavedViewTranslation.ts
+++ b/packages/saved-views-react/src/api/utilities/translation/SavedViewTranslation.ts
@@ -4,8 +4,8 @@
 *--------------------------------------------------------------------------------------------*/
 import { IModelReadRpcInterface, type ViewQueryParams, type ViewStateProps } from "@itwin/core-common";
 import {
-  DisplayStyle3dState, DrawingViewState, EmphasizeElements, SheetViewState, SpatialViewState, type BlankConnection,
-  type IModelConnection, type ViewState, type Viewport,
+  DisplayStyle3dState, DrawingViewState, EmphasizeElements, SheetViewState, SpatialViewState, type IModelConnection,
+  type ViewState, type Viewport,
 } from "@itwin/core-frontend";
 import {
   isViewDataITwin3d, isViewDataITwinDrawing, isViewDataITwinSheet, type SavedViewRepresentation,
@@ -255,10 +255,14 @@ async function fetchIModelViewData(iModel: IModelConnection, viewClassName: View
   }
 
   const viewId = await getDefaultViewIdFromClassName(iModel, viewClassName);
+  if (viewId === "") {
+    return manufactureEmptyViewState(iModel, viewClassName);
+  }
+
   return iModel.views.load(viewId);
 }
 
-function manufactureEmptyViewState(iModel: BlankConnection, viewClassName: ViewTypes): ViewState {
+function manufactureEmptyViewState(iModel: IModelConnection, viewClassName: ViewTypes): ViewState {
   const blankViewState = SpatialViewState.createBlank(
     iModel,
     { x: 0, y: 0, z: 0 },


### PR DESCRIPTION
No changelog entry because the fix is in undocumented experimental API.

Also fix view overrides not being cleared when applying a new saved view in the test app.