### PR TITLE
Capture and apply Saved View extension data

### DIFF
--- a/packages/saved-views-client/CHANGELOG.md
+++ b/packages/saved-views-client/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixes
 
-Remove `extensions` property from `UpdateSavedViewParams` because extensions are immutable
+* Remove `extensions` property from `UpdateSavedViewParams` because extensions are immutable
 
 ## [0.3.0](https://github.com/iTwin/saved-views/tree/v0.3.0-client/packages/saved-views-client) - 2024-05-16
 

--- a/packages/saved-views-client/CHANGELOG.md
+++ b/packages/saved-views-client/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased](https://github.com/iTwin/saved-views/tree/HEAD/packages/saved-views-client)
 
+### Fixes
+
+Remove `extensions` property from `UpdateSavedViewParams` because extensions are immutable
+
 ## [0.3.0](https://github.com/iTwin/saved-views/tree/v0.3.0-client/packages/saved-views-client) - 2024-05-16
 
 ### Minor changes

--- a/packages/saved-views-client/src/client/ITwinSavedViewsClient.test.ts
+++ b/packages/saved-views-client/src/client/ITwinSavedViewsClient.test.ts
@@ -133,7 +133,6 @@ describe("ITwinSavedViewsClient", () => {
       displayName: "test_displayname",
       shared: true,
       tagIds: ["test_tagid"],
-      extensions: [{ extensionName: "test_extensionname", href: "not_supposed_to_be_here" }],
     });
 
     verifyFetch({
@@ -145,7 +144,6 @@ describe("ITwinSavedViewsClient", () => {
         displayName: "test_displayname",
         shared: true,
         tagIds: ["test_tagid"],
-        extensions: [{ extensionName: "test_extensionname", href: "not_supposed_to_be_here" }],
       }),
     });
   });

--- a/packages/saved-views-client/src/client/SavedViewsClient.ts
+++ b/packages/saved-views-client/src/client/SavedViewsClient.ts
@@ -2,7 +2,7 @@
 * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
-import type { Extension, ExtensionListItem, ExtensionMin, ExtensionSavedViewCreate } from "../models/Extension.js";
+import type { Extension, ExtensionListItem, ExtensionSavedViewCreate } from "../models/Extension.js";
 import type { Group } from "../models/Group.js";
 import type { HalLinks } from "../models/Links.js";
 import type { Tag } from "../models/Tag.js";
@@ -68,7 +68,6 @@ export interface UpdateSavedViewParams extends CommonRequestParams {
   displayName?: string;
   shared?: boolean;
   tagIds?: string[];
-  extensions?: ExtensionMin[];
 }
 
 export interface SavedViewMinimalResponse {

--- a/packages/saved-views-react/CHANGELOG.md
+++ b/packages/saved-views-react/CHANGELOG.md
@@ -6,6 +6,26 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased](https://github.com/iTwin/saved-views/tree/HEAD/packages/saved-views-react)
 
+### Breaking changes
+
+* `captureSavedViewData` now also captures extension data thus return type has now changed to `{ viewData: ViewData; extensions: SavedViewExtension[] | undefined }`
+* `SavedViewsClient.createSavedView`: Update parameter bag to reflect `SavedView` change (see minor changes)
+* `SavedViewsClient.updateSavedView`: Update parameter bag to reflect `SavedView` change (see minor changes)
+* `useSavedViews`: Update `submitSavedView` action parameters to reflect `SavedView` change (see minor changes)
+
+### Minor changes
+
+* `SavedView` now also contains `viewData` and `extension` properties
+
+### Fixes
+
+* `ITwinSavedViewsClient.createSavedView`: Extension data now is no longer ignored
+* `ITwinSavedViewsClient.updateSavedView`: Fix extension data not being updated
+
+### Dependencies
+
+* Bump `@itwin/saved-views-client` package version from `^0.3.0` to `^0.3.1`
+
 ## [0.5.0](https://github.com/iTwin/saved-views/tree/v0.5.0-react/packages/saved-views-react) - 2024-06-03
 
 ### Breaking changes

--- a/packages/saved-views-react/src/SavedView.ts
+++ b/packages/saved-views-react/src/SavedView.ts
@@ -2,22 +2,28 @@
 * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
+import type { ViewData } from "@itwin/saved-views-client";
 import type { ReactNode } from "react";
 
 export interface SavedView {
   id: string;
   displayName: string;
+  viewData?: ViewData | undefined;
   groupId?: string | undefined;
   creatorId?: string | undefined;
   tagIds?: string[] | undefined;
   shared?: boolean | undefined;
   thumbnail?: ReactNode | string | undefined;
-  /** `extensionName` and `data` pairs. */
-  extensions?: Map<string, string> | undefined;
+  extensions?: SavedViewExtension[] | undefined;
   /** Time the saved view was created as an ISO8601 string, `"YYYY-MM-DDTHH:mm:ss.sssZ"` */
-  creationTime?: string;
+  creationTime?: string | undefined;
   /** Time the saved view was last modified as an ISO8601 string, `"YYYY-MM-DDTHH:mm:ss.sssZ"` */
-  lastModified?: string;
+  lastModified?: string | undefined;
+}
+
+export interface SavedViewExtension {
+  extensionName: string;
+  data: string;
 }
 
 export interface SavedViewTag {
@@ -31,3 +37,5 @@ export interface SavedViewGroup {
   creatorId?: string | undefined;
   shared?: boolean | undefined;
 }
+
+export type WriteableSavedViewProperties = Omit<SavedView, "id" | "creatorId" | "creationTime" | "lastModified">;

--- a/packages/saved-views-react/src/SavedViewsClient/SavedViewsClient.ts
+++ b/packages/saved-views-react/src/SavedViewsClient/SavedViewsClient.ts
@@ -2,11 +2,10 @@
 * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
-import type {
-  ExtensionMin, ExtensionSavedViewCreate, SavedViewRepresentation, ViewData,
-} from "@itwin/saved-views-client";
+import type { SavedViewRepresentation } from "@itwin/saved-views-client";
 
-import type { SavedView, SavedViewGroup, SavedViewTag } from "../SavedView.js";
+import type { SavedView, SavedViewGroup, SavedViewTag, WriteableSavedViewProperties } from "../SavedView.js";
+import type { PartialExcept } from "../utils.js";
 
 export interface SavedViewInfo {
   savedViews: SavedView[];
@@ -52,15 +51,11 @@ export interface UploadThumbnailParams extends CommonParams {
 export interface CreateSavedViewParams extends CommonParams {
   iTwinId: string;
   iModelId?: string | undefined;
-  savedView: Pick<SavedView, "displayName" | "tagIds" | "groupId" | "shared">;
-  savedViewData: ViewData;
-  extensions?: ExtensionSavedViewCreate[] | undefined;
+  savedView: PartialExcept<WriteableSavedViewProperties, "displayName" | "viewData">;
 }
 
 export interface UpdateSavedViewParams extends CommonParams {
-  savedView: Pick<SavedView, "id"> & Partial<SavedView>;
-  savedViewData?: ViewData | undefined;
-  extensions?: ExtensionMin[] | undefined;
+  savedView: Partial<WriteableSavedViewProperties> & { id: string; };
 }
 
 export interface DeleteSavedViewParams extends CommonParams {

--- a/packages/saved-views-react/src/utils.ts
+++ b/packages/saved-views-react/src/utils.ts
@@ -3,6 +3,8 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 
+export type PartialExcept<T, K extends keyof T> = Partial<Omit<T, K>> & Pick<Required<T>, K>;
+
 export function trimInputString(string: string): string {
   return string.replace(/\s+/g, " ");
 }

--- a/packages/test-app-frontend/src/App/ITwinJsApp/SavedViewsWidget.tsx
+++ b/packages/test-app-frontend/src/App/ITwinJsApp/SavedViewsWidget.tsx
@@ -67,8 +67,12 @@ export function SavedViewsWidget(props: SavedViewsWidgetProps): ReactElement {
   }
 
   const handleCreateView = async () => {
-    const savedViewData = await captureSavedViewData({ viewport: props.viewport });
-    const savedViewId = await savedViews.actions.submitSavedView("0 Saved View Name", savedViewData);
+    const { viewData, extensions } = await captureSavedViewData({ viewport: props.viewport });
+    const savedViewId = await savedViews.actions.submitSavedView({
+      displayName: "0 Saved View Name",
+      viewData,
+      extensions,
+    });
     const thumbnail = captureSavedViewThumbnail(props.viewport);
     if (thumbnail) {
       savedViews.actions.uploadThumbnail(savedViewId, thumbnail);


### PR DESCRIPTION
## @itwin/saved-views-client

### Fixes

* Remove `extensions` property from `UpdateSavedViewParams` because extensions are immutable

## @itwin/saved-views-react

### Breaking changes

* `captureSavedViewData` now also captures extension data thus return type has now changed to `{ viewData: ViewData; extensions: SavedViewExtension[] | undefined }`
* `SavedViewsClient.createSavedView`: Update parameter bag to reflect `SavedView` change (see minor changes)
* `SavedViewsClient.updateSavedView`: Update parameter bag to reflect `SavedView` change (see minor changes)
* `useSavedViews`: Update `submitSavedView` action parameters to reflect `SavedView` change (see minor changes)

### Minor changes

* `SavedView` now also contains `viewData` and `extension` properties

### Fixes

* `ITwinSavedViewsClient.createSavedView`: Extension data now is no longer ignored
* `ITwinSavedViewsClient.updateSavedView`: Fix extension data not being updated

### Dependencies

* Bump `@itwin/saved-views-client` package version from `^0.3.0` to `^0.3.1`