### PR TITLE
Make changes to client APIs

### DIFF
--- a/packages/saved-views-client/CHANGELOG.md
+++ b/packages/saved-views-client/CHANGELOG.md
@@ -6,9 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased](https://github.com/iTwin/saved-views/tree/HEAD/packages/saved-views-client)
 
+### Breaking changes
+
+* `SavedViewsClient` interface changes
+  * `getAllSavedViewsMinimal` and `getAllSavedViewsRepresentation` now return `AsyncIterableIterator` to better emphasize that results are delivered in pages
+  * `createSavedView` and `updateSavedView` now return `SavedViewRepresentationResponse` to match the current iTwin API behavior
+
 ### Fixes
 
 * Remove `extensions` property from `UpdateSavedViewParams` because extensions are immutable
+* `ITwinSavedViewsClient`: Fix fetch requests failing when request body contains forbidden characters
 
 ## [0.3.0](https://github.com/iTwin/saved-views/tree/v0.3.0-client/packages/saved-views-client) - 2024-05-16
 

--- a/packages/saved-views-client/src/client/ITwinSavedViewsClient.test.ts
+++ b/packages/saved-views-client/src/client/ITwinSavedViewsClient.test.ts
@@ -58,7 +58,7 @@ describe("ITwinSavedViewsClient", () => {
       groupId: "test_groupid",
       top: "test_top",
       skip: "test_skip",
-    });
+    }).next();
 
     verifyFetch({
       url: "https://api.bentley.com/savedviews/?iTwinId=test_itwinid&iModelId=test_imodelid&groupId=test_groupid&$top=test_top&$skip=test_skip",
@@ -73,7 +73,7 @@ describe("ITwinSavedViewsClient", () => {
     const client = new ITwinSavedViewsClient({ getAccessToken });
     await client.getAllSavedViewsMinimal({
       groupId: "test_groupid",
-    });
+    }).next();
 
     verifyFetch({
       url: "https://api.bentley.com/savedviews/?groupId=test_groupid",
@@ -92,7 +92,7 @@ describe("ITwinSavedViewsClient", () => {
       groupId: "test_groupid",
       top: "test_top",
       skip: "test_skip",
-    });
+    }).next();
 
     verifyFetch({
       url: "https://api.bentley.com/savedviews/?iTwinId=test_itwinid&iModelId=test_imodelid&groupId=test_groupid&$top=test_top&$skip=test_skip",

--- a/packages/saved-views-client/src/client/SavedViewsClient.ts
+++ b/packages/saved-views-client/src/client/SavedViewsClient.ts
@@ -11,10 +11,10 @@ import type { SavedViewMinimal, SavedViewRepresentation, ViewData } from "../mod
 export interface SavedViewsClient {
   getSavedViewMinimal(args: SingleSavedViewParams): Promise<SavedViewMinimalResponse>;
   getSavedViewRepresentation(args: SingleSavedViewParams): Promise<SavedViewRepresentationResponse>;
-  getAllSavedViewsMinimal(args: GetSavedViewsParams): Promise<SavedViewListMinimalResponse>;
-  getAllSavedViewsRepresentation(args: GetSavedViewsParams): Promise<SavedViewListRepresentationResponse>;
-  createSavedView(args: CreateSavedViewParams): Promise<SavedViewMinimalResponse>;
-  updateSavedView(args: UpdateSavedViewParams): Promise<SavedViewMinimalResponse>;
+  getAllSavedViewsMinimal(args: GetSavedViewsParams): AsyncIterableIterator<SavedViewListMinimalResponse>;
+  getAllSavedViewsRepresentation(args: GetSavedViewsParams): AsyncIterableIterator<SavedViewListRepresentationResponse>;
+  createSavedView(args: CreateSavedViewParams): Promise<SavedViewRepresentationResponse>;
+  updateSavedView(args: UpdateSavedViewParams): Promise<SavedViewRepresentationResponse>;
   deleteSavedView(args: SingleSavedViewParams): Promise<void>;
 
   getImage(args: GetImageParams): Promise<ImageResponse>;

--- a/packages/saved-views-react/CHANGELOG.md
+++ b/packages/saved-views-react/CHANGELOG.md
@@ -8,19 +8,26 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Breaking changes
 
+* `SavedViewsClient` interface changes
+  * Remove `getSavedViewInfo` method
+  * Add `getAllSavedViews`, `getAllGroups`, and `getAllTags` methods as replacement for `getSavedViewInfo`
+  * Rename `getSingularSavedView` method to `getSavedView`
 * `captureSavedViewData` now also captures extension data thus return type has now changed to `{ viewData: ViewData; extensions: SavedViewExtension[] | undefined }`
 * `SavedViewsClient.createSavedView`: Update parameter bag to reflect `SavedView` change (see minor changes)
 * `SavedViewsClient.updateSavedView`: Update parameter bag to reflect `SavedView` change (see minor changes)
 * `useSavedViews`: Update `submitSavedView` action parameters to reflect `SavedView` change (see minor changes)
+* Update `applySavedView` parameter types. `savedViewData` is now a subset of `SavedView` object.
 
 ### Minor changes
 
-* `SavedView` now also contains `viewData` and `extension` properties
+* `SavedView` now also contains optional `viewData` and `extension` properties. Objects returned by `ITwinSavedViewsClient` will have these fields populated.
+* Permit `ApplySavedViewSettings.viewState` value to be `"reset"`. Due to technicalities, it has the same semantics as `"apply"`.
 
 ### Fixes
 
 * `ITwinSavedViewsClient.createSavedView`: Extension data now is no longer ignored
 * `ITwinSavedViewsClient.updateSavedView`: Fix extension data not being updated
+* `ITwinSavedViewsClient.deleteGroup` now correctly attempts to delete multiple pages of Saved Views
 
 ### Dependencies
 

--- a/packages/saved-views-react/src/SavedViewsClient/ITwinSavedViewsClient.ts
+++ b/packages/saved-views-react/src/SavedViewsClient/ITwinSavedViewsClient.ts
@@ -3,15 +3,14 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 import {
-  ITwinSavedViewsClient as Client, type Group, type SavedViewMinimal, type SavedViewRepresentation,
-  type Tag,
+  ITwinSavedViewsClient as Client, type Group, type SavedViewRepresentation, type Tag,
 } from "@itwin/saved-views-client";
 
 import type { SavedView, SavedViewGroup, SavedViewTag } from "../SavedView.js";
 import type {
   CreateGroupParams, CreateSavedViewParams, CreateTagParams, DeleteGroupParams, DeleteSavedViewParams, DeleteTagParams,
-  GetSavedViewInfoParams, GetSingularSavedViewParams, GetThumbnailUrlParams, SavedViewInfo, SavedViewsClient,
-  UpdateGroupParams, UpdateSavedViewParams, UpdateTagParams, UploadThumbnailParams,
+  GetAllGroupsParams, GetAllSavedViewsParams, GetAllTagsParams, GetSavedViewParams, GetThumbnailUrlParams,
+  SavedViewsClient, UpdateGroupParams, UpdateSavedViewParams, UpdateTagParams, UploadThumbnailParams,
 } from "./SavedViewsClient.js";
 
 interface ITwinSavedViewsClientParams {
@@ -25,38 +24,44 @@ interface ITwinSavedViewsClientParams {
   baseUrl?: string | undefined;
 }
 
-/**  */
 export class ITwinSavedViewsClient implements SavedViewsClient {
-  private client: Client;
+  #client: Client;
 
   constructor(args: ITwinSavedViewsClientParams) {
-    this.client = new Client(args);
+    this.#client = new Client(args);
   }
 
-  public async getSavedViewInfo(args: GetSavedViewInfoParams): Promise<SavedViewInfo> {
-    const [{ savedViews }, { groups }, { tags }] = await Promise.all([
-      this.client.getAllSavedViewsMinimal(args),
-      this.client.getAllGroups(args),
-      this.client.getAllTags(args),
-    ]);
-
-    return {
-      savedViews: savedViews.map(savedViewResponseToSavedView),
-      groups: groups.map(groupResponseToSavedViewGroup),
-      tags: tags.map(tagResponseToSavedViewTag),
-    };
-  }
-
-  public async getSingularSavedView(args: GetSingularSavedViewParams): Promise<SavedViewRepresentation> {
-    const response = await this.client.getSavedViewRepresentation({
-      savedViewId: args.savedViewId,
+  async *getAllSavedViews(args: GetAllSavedViewsParams): AsyncIterableIterator<SavedView[]> {
+    const iterable = this.#client.getAllSavedViewsRepresentation({
+      iTwinId: args.iTwinId,
+      iModelId: args.iModelId,
       signal: args.signal,
     });
-    return response.savedView;
+    for await (const page of iterable) {
+      yield page.savedViews.map(savedViewResponseToSavedView);
+    }
   }
 
-  public async getThumbnailUrl(args: GetThumbnailUrlParams): Promise<string | undefined> {
-    const response = await this.client.getImage({
+  async getAllGroups(args: GetAllGroupsParams): Promise<SavedViewGroup[]> {
+    const response = await this.#client.getAllGroups({
+      iTwinId: args.iTwinId,
+      iModelId: args.iModelId,
+      signal: args.signal,
+    });
+    return response.groups.map(groupResponseToSavedViewGroup);
+  }
+
+  async getAllTags(args: GetAllTagsParams): Promise<SavedViewTag[]> {
+    const response = await this.#client.getAllTags({
+      iTwinId: args.iTwinId,
+      iModelId: args.iModelId,
+      signal: args.signal,
+    });
+    return response.tags.map(tagResponseToSavedViewTag);
+  }
+
+  async getThumbnailUrl(args: GetThumbnailUrlParams): Promise<string | undefined> {
+    const response = await this.#client.getImage({
       savedViewId: args.savedViewId,
       size: "thumbnail",
       signal: args.signal,
@@ -64,16 +69,23 @@ export class ITwinSavedViewsClient implements SavedViewsClient {
     return response.href;
   }
 
-  public async uploadThumbnail(args: UploadThumbnailParams): Promise<void> {
-    await this.client.updateImage({
+  async uploadThumbnail(args: UploadThumbnailParams): Promise<void> {
+    await this.#client.updateImage({
       savedViewId: args.savedViewId,
       image: args.image,
       signal: args.signal,
     });
   }
 
-  public async createSavedView(args: CreateSavedViewParams): Promise<SavedView> {
-    const { savedView } = await this.client.createSavedView({
+  async getSavedView(args: GetSavedViewParams): Promise<SavedView> {
+    const response = await this.#client.getSavedViewRepresentation({
+      savedViewId: args.savedViewId,
+      signal: args.signal,
+    });
+    return savedViewResponseToSavedView(response.savedView);
+  }
+  async createSavedView(args: CreateSavedViewParams): Promise<SavedView> {
+    const { savedView } = await this.#client.createSavedView({
       iTwinId: args.iTwinId,
       iModelId: args.iModelId,
       displayName: args.savedView.displayName,
@@ -87,8 +99,8 @@ export class ITwinSavedViewsClient implements SavedViewsClient {
     return savedViewResponseToSavedView(savedView);
   }
 
-  public async updateSavedView(args: UpdateSavedViewParams): Promise<SavedView> {
-    const { savedView } = await this.client.updateSavedView({
+  async updateSavedView(args: UpdateSavedViewParams): Promise<SavedView> {
+    const { savedView } = await this.#client.updateSavedView({
       savedViewId: args.savedView.id,
       displayName: args.savedView.displayName,
       tagIds: args.savedView.tagIds,
@@ -99,7 +111,7 @@ export class ITwinSavedViewsClient implements SavedViewsClient {
     });
 
     await Promise.all((args.savedView.extensions ?? []).map(
-      ({ extensionName, data }) => this.client.createExtension({
+      ({ extensionName, data }) => this.#client.createExtension({
         savedViewId: args.savedView.id,
         extensionName,
         data,
@@ -109,12 +121,12 @@ export class ITwinSavedViewsClient implements SavedViewsClient {
     return savedViewResponseToSavedView(savedView);
   }
 
-  public async deleteSavedView(args: DeleteSavedViewParams): Promise<void> {
-    await this.client.deleteSavedView({ savedViewId: args.savedViewId, signal: args.signal });
+  async deleteSavedView(args: DeleteSavedViewParams): Promise<void> {
+    await this.#client.deleteSavedView({ savedViewId: args.savedViewId, signal: args.signal });
   }
 
-  public async createGroup(args: CreateGroupParams): Promise<SavedViewGroup> {
-    const { group } = await this.client.createGroup({
+  async createGroup(args: CreateGroupParams): Promise<SavedViewGroup> {
+    const { group } = await this.#client.createGroup({
       iTwinId: args.iTwinId,
       iModelId: args.iModelId,
       displayName: args.group.displayName,
@@ -123,8 +135,8 @@ export class ITwinSavedViewsClient implements SavedViewsClient {
     return groupResponseToSavedViewGroup(group);
   }
 
-  public async updateGroup(args: UpdateGroupParams): Promise<SavedViewGroup> {
-    const { group } = await this.client.updateGroup({
+  async updateGroup(args: UpdateGroupParams): Promise<SavedViewGroup> {
+    const { group } = await this.#client.updateGroup({
       groupId: args.group.id,
       displayName: args.group.displayName,
       shared: args.group.shared,
@@ -133,16 +145,19 @@ export class ITwinSavedViewsClient implements SavedViewsClient {
     return groupResponseToSavedViewGroup(group);
   }
 
-  public async deleteGroup(args: DeleteGroupParams): Promise<void> {
-    const savedViews = await this.client.getAllSavedViewsMinimal({ groupId: args.groupId, signal: args.signal });
-    await Promise.all(
-      savedViews.savedViews.map(({ id }) => this.client.deleteSavedView({ savedViewId: id, signal: args.signal })),
-    );
-    await this.client.deleteGroup({ groupId: args.groupId, signal: args.signal });
+  async deleteGroup(args: DeleteGroupParams): Promise<void> {
+    const savedViewPages = this.#client.getAllSavedViewsMinimal({ groupId: args.groupId, signal: args.signal });
+    for await (const savedViews of savedViewPages) {
+      await Promise.all(
+        savedViews.savedViews.map(({ id }) => this.#client.deleteSavedView({ savedViewId: id, signal: args.signal })),
+      );
+    }
+
+    await this.#client.deleteGroup({ groupId: args.groupId, signal: args.signal });
   }
 
-  public async createTag(args: CreateTagParams): Promise<SavedViewTag> {
-    const { tag } = await this.client.createTag({
+  async createTag(args: CreateTagParams): Promise<SavedViewTag> {
+    const { tag } = await this.#client.createTag({
       iTwinId: args.iTwinId,
       iModelId: args.iModelId,
       displayName: args.displayName,
@@ -151,8 +166,8 @@ export class ITwinSavedViewsClient implements SavedViewsClient {
     return tagResponseToSavedViewTag(tag);
   }
 
-  public async updateTag(args: UpdateTagParams): Promise<SavedViewTag> {
-    const { tag } = await this.client.updateTag({
+  async updateTag(args: UpdateTagParams): Promise<SavedViewTag> {
+    const { tag } = await this.#client.updateTag({
       tagId: args.tag.id,
       displayName: args.tag.displayName,
       signal: args.signal,
@@ -160,22 +175,22 @@ export class ITwinSavedViewsClient implements SavedViewsClient {
     return tagResponseToSavedViewTag(tag);
   }
 
-  public async deleteTag(args: DeleteTagParams): Promise<void> {
-    await this.client.deleteTag({ tagId: args.tagId, signal: args.signal });
+  async deleteTag(args: DeleteTagParams): Promise<void> {
+    await this.#client.deleteTag({ tagId: args.tagId, signal: args.signal });
   }
 }
 
-function savedViewResponseToSavedView(response: Omit<SavedViewMinimal, "savedViewData">): SavedView {
+function savedViewResponseToSavedView(response: SavedViewRepresentation): SavedView {
   return {
     id: response.id,
     displayName: response.displayName,
-    viewData: undefined,
+    viewData: response.savedViewData,
     tagIds: response.tags?.map((tag) => tag.id),
     groupId: response._links.group?.href.split("/").at(-1),
     creatorId: response._links.creator?.href.split("/").at(-1),
     shared: response.shared,
     thumbnail: undefined,
-    extensions: undefined,
+    extensions: response.extensions,
     creationTime: response.creationTime,
     lastModified: response.lastModified,
   };

--- a/packages/saved-views-react/src/SavedViewsClient/SavedViewsClient.ts
+++ b/packages/saved-views-react/src/SavedViewsClient/SavedViewsClient.ts
@@ -2,22 +2,16 @@
 * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
-import type { SavedViewRepresentation } from "@itwin/saved-views-client";
-
 import type { SavedView, SavedViewGroup, SavedViewTag, WriteableSavedViewProperties } from "../SavedView.js";
 import type { PartialExcept } from "../utils.js";
 
-export interface SavedViewInfo {
-  savedViews: SavedView[];
-  groups: SavedViewGroup[];
-  tags: SavedViewTag[];
-}
-
 export interface SavedViewsClient {
-  getSavedViewInfo: (args: GetSavedViewInfoParams) => Promise<SavedViewInfo>;
-  getSingularSavedView: (args: GetSingularSavedViewParams) => Promise<SavedViewRepresentation>;
+  getAllSavedViews: (args: GetAllSavedViewsParams) => AsyncIterableIterator<SavedView[]>;
+  getAllGroups: (args: GetAllGroupsParams) => Promise<SavedViewGroup[]>;
+  getAllTags: (args: GetAllTagsParams) => Promise<SavedViewTag[]>;
   getThumbnailUrl: (args: GetThumbnailUrlParams) => Promise<string | undefined>;
   uploadThumbnail: (args: UploadThumbnailParams) => Promise<void>;
+  getSavedView: (args: GetSavedViewParams) => Promise<SavedView>;
   createSavedView: (args: CreateSavedViewParams) => Promise<SavedView>;
   updateSavedView: (args: UpdateSavedViewParams) => Promise<SavedView>;
   deleteSavedView: (args: DeleteSavedViewParams) => Promise<void>;
@@ -29,13 +23,19 @@ export interface SavedViewsClient {
   deleteTag: (args: DeleteTagParams) => Promise<void>;
 }
 
-export interface GetSavedViewInfoParams extends CommonParams {
+export interface GetAllSavedViewsParams extends CommonParams {
   iTwinId: string;
   iModelId?: string | undefined;
 }
 
-export interface GetSingularSavedViewParams extends CommonParams {
-  savedViewId: string;
+export interface GetAllGroupsParams extends CommonParams {
+  iTwinId: string;
+  iModelId?: string | undefined;
+}
+
+export interface GetAllTagsParams extends CommonParams {
+  iTwinId: string;
+  iModelId?: string | undefined;
 }
 
 export interface GetThumbnailUrlParams extends CommonParams {
@@ -44,8 +44,17 @@ export interface GetThumbnailUrlParams extends CommonParams {
 
 export interface UploadThumbnailParams extends CommonParams {
   savedViewId: string;
-  /** Image data encoded as base64 data URL. */
+  /**
+   * Image data encoded as base64 data URL.
+   *
+   * @example
+   * "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVQYV2NgYAAAAAMAAWgmWQ0AAAAASUVORK5CYII="
+   */
   image: string;
+}
+
+export interface GetSavedViewParams extends CommonParams {
+  savedViewId: string;
 }
 
 export interface CreateSavedViewParams extends CommonParams {

--- a/packages/saved-views-react/src/applySavedView.ts
+++ b/packages/saved-views-react/src/applySavedView.ts
@@ -3,8 +3,8 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 import { ViewState, type IModelConnection, type Viewport } from "@itwin/core-frontend";
-import { type SavedViewRepresentation } from "@itwin/saved-views-client";
 
+import type { SavedView } from "./SavedView.js";
 import { createViewState } from "./createViewState.js";
 import { extensionHandlers, type ExtensionHandler } from "./translation/SavedViewsExtensionHandlers.js";
 

--- a/packages/saved-views-react/src/applySavedView.ts
+++ b/packages/saved-views-react/src/applySavedView.ts
@@ -35,7 +35,7 @@ export interface ApplySavedViewSettings {
    *   applySavedView(iModel, viewport2, savedView, { viewState }),
    * ]);
    */
-  viewState?: Exclude<ApplyStrategy, "reset"> | ViewState | undefined;
+  viewState?: ApplyStrategy | ViewState | undefined;
 
   /**
    * How to handle visibility of models and categories that exist in iModel but are not captured in Saved View data. Has
@@ -77,7 +77,7 @@ type ApplyStrategy = "apply" | "reset" | "keep";
 export async function applySavedView(
   iModel: IModelConnection,
   viewport: Viewport,
-  savedView: Pick<SavedViewRepresentation, "savedViewData" | "extensions">,
+  savedViewData: Pick<SavedView, "viewData" | "extensions">,
   settings: ApplySavedViewSettings | undefined = {},
 ): Promise<void> {
   const defaultStrategy = settings.all ?? "apply";
@@ -85,14 +85,14 @@ export async function applySavedView(
   if ((settings.viewState ?? defaultStrategy) !== "keep") {
     if (settings.viewState instanceof ViewState) {
       viewport.changeView(settings.viewState);
-    } else {
+    } else if (savedViewData.viewData) {
       const { modelAndCategoryVisibilityFallback } = settings;
-      const viewState = await createViewState(iModel, savedView.savedViewData, { modelAndCategoryVisibilityFallback });
+      const viewState = await createViewState(iModel, savedViewData.viewData, { modelAndCategoryVisibilityFallback });
       viewport.changeView(viewState);
     }
   }
 
-  const extensions = new Map(savedView.extensions?.map(({ extensionName, data }) => [extensionName, data]));
+  const extensions = new Map(savedViewData.extensions?.map(({ extensionName, data }) => [extensionName, data]));
   const processExtension = (extensionHandler: ExtensionHandler, strategy: ApplyStrategy = defaultStrategy) => {
     if (strategy === "keep") {
       return;

--- a/packages/saved-views-react/src/index.ts
+++ b/packages/saved-views-react/src/index.ts
@@ -10,8 +10,8 @@ export { useSavedViewTileContext, type SavedViewTileContext } from "./SavedViewT
 export { ITwinSavedViewsClient } from "./SavedViewsClient/ITwinSavedViewsClient.js";
 export type {
   CreateGroupParams, CreateSavedViewParams, CreateTagParams, DeleteGroupParams, DeleteSavedViewParams, DeleteTagParams,
-  GetSavedViewInfoParams, GetSingularSavedViewParams, GetThumbnailUrlParams, SavedViewInfo, SavedViewsClient,
-  UpdateGroupParams, UpdateSavedViewParams, UpdateTagParams, UploadThumbnailParams,
+  GetAllGroupsParams, GetAllSavedViewsParams, GetAllTagsParams, GetSavedViewParams, GetThumbnailUrlParams,
+  SavedViewsClient, UpdateGroupParams, UpdateSavedViewParams, UpdateTagParams, UploadThumbnailParams,
 } from "./SavedViewsClient/SavedViewsClient.js";
 export { SavedViewsContextProvider, type SavedViewsContext } from "./SavedViewsContext.js";
 export { StickyExpandableBlock } from "./StickyExpandableBlock/StickyExpandableBlock.js";

--- a/packages/test-app-frontend/src/App/ITwinJsApp/SavedViewsWidget.tsx
+++ b/packages/test-app-frontend/src/App/ITwinJsApp/SavedViewsWidget.tsx
@@ -55,8 +55,7 @@ export function SavedViewsWidget(props: SavedViewsWidgetProps): ReactElement {
         return;
       }
 
-      const savedViewResponse = await client.getSingularSavedView({ savedViewId });
-      await applySavedView(props.iModel, props.viewport, savedViewResponse);
+      await applySavedView(props.iModel, props.viewport, savedView);
     } finally {
       close();
     }


### PR DESCRIPTION
Documentation update coming in a follow-up PR.

## @itwin/saved-views-client

### Breaking changes

* `SavedViewsClient` interface changes
  * `getAllSavedViewsMinimal` and `getAllSavedViewsRepresentation` now return `AsyncIterableIterator` to better emphasize that results are delivered in pages
  * `createSavedView` and `updateSavedView` now return `SavedViewRepresentationResponse` to match the current iTwin API behavior

### Fixes

* `ITwinSavedViewsClient`: Fix fetch requests failing when request body contains forbidden characters

## @itwin/saved-views-react

### Breaking changes

* `SavedViewsClient` interface changes
  * Remove `getSavedViewInfo` method
  * Add `getAllSavedViews`, `getAllGroups`, and `getAllTags` methods as replacement for `getSavedViewInfo`
  * Rename `getSingularSavedView` method to `getSavedView`
* Update `applySavedView` parameter types. `savedViewData` is now a subset of `SavedView` object.

### Minor changes

* `ITwinSavedViewsClient` populates `viewData` and `extensions` properties of returned `SavedView` objects
* Permit `ApplySavedViewSettings.viewState` value to be `"reset"`. Due to technicalities, it has the same semantics as `"apply"`.

### Fixes

* `ITwinSavedViewsClient.deleteGroup` now correctly attempts to delete multiple pages of Saved Views
