### PR TITLE
Apply minor fixes to the release script

### DIFF
--- a/packages/saved-views-client/publish.yaml
+++ b/packages/saved-views-client/publish.yaml
@@ -1,7 +1,7 @@
 trigger:
   tags:
     include:
-      - v*.*.*-client
+      - client-v*.*.*
 
 pr: none
 
@@ -9,8 +9,8 @@ variables:
   - name: packageName
     value: saved-views-client
   - name: packageVersion
-    # Build.SourceBranchName will be a tag that triggereed the pipeline, like "v1.2.3-client"
-    value: ${{ replace(replace(variables['Build.SourceBranchName'], '-client', ''), 'v', '') }}
+    # Build.SourceBranchName will be a tag that triggereed the pipeline, like "client-v1.2.3"
+    value: ${{ replace(replace(variables['Build.SourceBranchName'], 'client-', ''), 'v', '') }}
   - name: tarballName
     value: itwin-$(packageName)-$(packageVersion).tgz
 

--- a/packages/saved-views-react/publish.yaml
+++ b/packages/saved-views-react/publish.yaml
@@ -1,7 +1,7 @@
 trigger:
   tags:
     include:
-      - v*.*.*-react
+      - react-v*.*.*
 
 pr: none
 
@@ -9,8 +9,8 @@ variables:
   - name: packageName
     value: saved-views-react
   - name: packageVersion
-    # Build.SourceBranchName will be a tag that triggereed the pipeline, like "v1.2.3-react"
-    value: ${{ replace(replace(variables['Build.SourceBranchName'], '-react', ''), 'v', '') }}
+    # Build.SourceBranchName will be a tag that triggereed the pipeline, like "react-v1.2.3"
+    value: ${{ replace(replace(variables['Build.SourceBranchName'], 'react-', ''), 'v', '') }}
   - name: tarballName
     value: itwin-$(packageName)-$(packageVersion).tgz
 


### PR DESCRIPTION
* Fix unbalanced parentheses in a regex pattern
* Fix wrong branch name being reported before publishing post-release branch
* Use highlighting more sparingly
* Update package publishing pipelines to reflect the change to release tag format. I have already marked this new tag pattern as protected in this GitHub repository.