### PR TITLE
Add fixes for modelExtent

### DIFF
--- a/packages/saved-views-client/CHANGELOG.md
+++ b/packages/saved-views-client/CHANGELOG.md
@@ -6,60 +6,64 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased](https://github.com/iTwin/saved-views/tree/HEAD/packages/saved-views-client)
 
+### Minor changes
+
+- Change `transformation` property from `ShapeProps` and `modelExtents` property from `ViewITwinDrawing` to be optional
+
 ## [0.4.0](https://github.com/iTwin/saved-views/tree/client-v0.4.0/packages/saved-views-client/) - 2024-07-22
 
 ### Breaking changes
 
-* `SavedViewsClient` interface changes
-  * `getAllSavedViewsMinimal` and `getAllSavedViewsRepresentation` now return `AsyncIterableIterator` to better emphasize that results are delivered in pages
-  * `createSavedView` and `updateSavedView` now return `SavedViewRepresentationResponse` to match the current iTwin API behavior
+- `SavedViewsClient` interface changes
+  - `getAllSavedViewsMinimal` and `getAllSavedViewsRepresentation` now return `AsyncIterableIterator` to better emphasize that results are delivered in pages
+  - `createSavedView` and `updateSavedView` now return `SavedViewRepresentationResponse` to match the current iTwin API behavior
 
 ### Fixes
 
-* Remove `extensions` property from `UpdateSavedViewParams` because extensions are immutable
-* `ITwinSavedViewsClient`: Fix fetch requests failing when request body contains forbidden characters
+- Remove `extensions` property from `UpdateSavedViewParams` because extensions are immutable
+- `ITwinSavedViewsClient`: Fix fetch requests failing when request body contains forbidden characters
 
 ## [0.3.0](https://github.com/iTwin/saved-views/tree/v0.3.0-client/packages/saved-views-client) - 2024-05-16
 
 ### Minor changes
 
-* Add `creationTime` and `lastModified` properties to `SavedView` type
+- Add `creationTime` and `lastModified` properties to `SavedView` type
 
 ## [0.2.2](https://github.com/iTwin/saved-views/tree/v0.2.2-client/packages/saved-views-client) - 2024-05-09
 
 ### Minor changes
 
-* Add optional readOnly property to `CreateGroupParams`, `UpdateGroupParams`, and `Group` types
+- Add optional readOnly property to `CreateGroupParams`, `UpdateGroupParams`, and `Group` types
 
 ## [0.2.1](https://github.com/iTwin/saved-views/tree/v0.2.1-client/packages/saved-views-client) - 2024-05-07
 
 ### Fixes
 
-* Fix `ITwinSavedViewsClient.updateSavedView` failing when saved view data contains URL fields
+- Fix `ITwinSavedViewsClient.updateSavedView` failing when saved view data contains URL fields
 
 ## [0.2.0](https://github.com/iTwin/saved-views/tree/v0.2.0-client/packages/saved-views-client) - 2024-04-08
 
 ### Breaking changes
 
-* Remove `SavedViewBase` type
-* Omit `savedViewData` property from `SavedViewListMinimalResponse` type
-* Rename types
-    * `SavedViewWithDataMinimal` -> `SavedViewMinimal`
-    * `SavedViewWithDataRepresentation` -> `SavedViewRepresentation`
-    * `ViewDataItwin3d` -> `ViewDataITwin3d`
+- Remove `SavedViewBase` type
+- Omit `savedViewData` property from `SavedViewListMinimalResponse` type
+- Rename types
+  - `SavedViewWithDataMinimal` -> `SavedViewMinimal`
+  - `SavedViewWithDataRepresentation` -> `SavedViewRepresentation`
+  - `ViewDataItwin3d` -> `ViewDataITwin3d`
 
 ### Minor changes
 
-* Add new type guards to discern `ViewData` union members
-    * `isViewDataITwin3d`
-    * `isViewDataITwinDrawing`
-    * `isViewDataITwinSheet`
-* `package.json`: Define `types` field to help ES module users that have badly configured `tsconfig.json`
+- Add new type guards to discern `ViewData` union members
+  - `isViewDataITwin3d`
+  - `isViewDataITwinDrawing`
+  - `isViewDataITwinSheet`
+- `package.json`: Define `types` field to help ES module users that have badly configured `tsconfig.json`
 
 ### Fixes
 
-* Fix `DELETE` operations throwing due to empty response body
-* Fix being unable to send Saved View to iTwin Saved Views service when `savedViewData` contains URL fields
+- Fix `DELETE` operations throwing due to empty response body
+- Fix being unable to send Saved View to iTwin Saved Views service when `savedViewData` contains URL fields
 
 ## [0.1.0](https://github.com/iTwin/saved-views/tree/v0.1.0-client/packages/saved-views-client) - 2024-02-01
 

--- a/packages/saved-views-client/src/models/savedViews/View.ts
+++ b/packages/saved-views-client/src/models/savedViews/View.ts
@@ -85,7 +85,7 @@ export interface ViewITwinDrawing extends ViewITwin2d {
     [qx: number, qy: number, qz: number, ax: number],
     [qx: number, qy: number, qz: number, ax: number],
   ];
-  modelExtents: [
+  modelExtents?: [
     low: [x: number, y: number, z: number],
     high: [x: number, y: number, z: number],
   ];

--- a/packages/saved-views-client/src/models/savedViews/View.ts
+++ b/packages/saved-views-client/src/models/savedViews/View.ts
@@ -139,7 +139,7 @@ export interface ClipPrimitiveShapeProps {
 /** Contains the shape/polygon used to clip the view. */
 export interface ShapeProps {
   points: number[][];
-  transform: [
+  transform?: [
     [qx: number, qy: number, qz: number, ax: number],
     [qx: number, qy: number, qz: number, ax: number],
     [qx: number, qy: number, qz: number, ax: number],

--- a/packages/saved-views-react/src/captureSavedViewData.ts
+++ b/packages/saved-views-react/src/captureSavedViewData.ts
@@ -160,7 +160,6 @@ function createDrawingSavedViewObject(vp: Viewport, hiddenCategories: Id64Array 
 
   return {
     itwinDrawingView: {
-      modelExtents: {} as ViewITwinDrawing["modelExtents"],
       baseModelId: viewDefinitionProps.baseModelId,
       origin: toArrayVector2d(viewDefinitionProps.origin),
       delta: toArrayVector2d(viewDefinitionProps.delta),

--- a/packages/saved-views-react/src/captureSavedViewData.ts
+++ b/packages/saved-views-react/src/captureSavedViewData.ts
@@ -5,7 +5,7 @@
 import { Id64Array } from "@itwin/core-bentley";
 import { QueryRowFormat, type SpatialViewDefinitionProps } from "@itwin/core-common";
 import {
-  type DrawingViewState, type IModelConnection, type SheetViewState, type SpatialViewState, type Viewport,
+  type DrawingViewState, type IModelConnection, type SheetViewState, type SpatialViewState, type Viewport
 } from "@itwin/core-frontend";
 import { type AngleProps, type XYProps, type XYZProps, type YawPitchRollProps } from "@itwin/core-geometry";
 import {

--- a/packages/saved-views-react/src/captureSavedViewData.ts
+++ b/packages/saved-views-react/src/captureSavedViewData.ts
@@ -5,12 +5,12 @@
 import { Id64Array } from "@itwin/core-bentley";
 import { QueryRowFormat, type SpatialViewDefinitionProps } from "@itwin/core-common";
 import {
-  type DrawingViewState, type IModelConnection, type SheetViewState, type SpatialViewState, type Viewport
+  type DrawingViewState, type IModelConnection, type SheetViewState, type SpatialViewState, type Viewport,
 } from "@itwin/core-frontend";
 import { type AngleProps, type XYProps, type XYZProps, type YawPitchRollProps } from "@itwin/core-geometry";
 import {
   type ViewData, type ViewDataITwin3d, type ViewDataITwinDrawing, type ViewDataITwinSheet,
-  type ViewYawPitchRoll
+  type ViewYawPitchRoll,
 } from "@itwin/saved-views-client";
 
 import type { SavedViewExtension } from "./SavedView.js";

--- a/packages/saved-views-react/src/captureSavedViewData.ts
+++ b/packages/saved-views-react/src/captureSavedViewData.ts
@@ -9,8 +9,8 @@ import {
 } from "@itwin/core-frontend";
 import { type AngleProps, type XYProps, type XYZProps, type YawPitchRollProps } from "@itwin/core-geometry";
 import {
-  type ViewData, type ViewDataITwin3d, type ViewDataITwinDrawing, type ViewDataITwinSheet, type ViewITwinDrawing,
-  type ViewYawPitchRoll,
+  type ViewData, type ViewDataITwin3d, type ViewDataITwinDrawing, type ViewDataITwinSheet,
+  type ViewYawPitchRoll
 } from "@itwin/saved-views-client";
 
 import type { SavedViewExtension } from "./SavedView.js";

--- a/packages/saved-views-react/src/translation/SavedViewTypes.ts
+++ b/packages/saved-views-react/src/translation/SavedViewTypes.ts
@@ -1,7 +1,7 @@
 /*---------------------------------------------------------------------------------------------
-* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
-* See LICENSE.md in the project root for license terms and full copyright notice.
-*--------------------------------------------------------------------------------------------*/
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
 import type { Id64Array } from "@itwin/core-bentley";
 import type {
   CategorySelectorProps, DisplayStyle3dProps, DisplayStyleProps, EmphasizeElementsProps, ModelSelectorProps,
@@ -12,7 +12,6 @@ import type { Range3dProps } from "@itwin/core-geometry";
 export interface LegacySavedView3d extends LegacySavedViewBase {
   displayStyleProps: DisplayStyle3dProps;
   modelSelectorProps: ModelSelectorProps;
-  modelExtents?: Range3dProps;
   viewDefinitionProps: SpatialViewDefinitionProps;
   perModelCategoryVisibility?: PerModelCategoryVisibilityProps[];
   hiddenModels?: Id64Array;
@@ -30,6 +29,7 @@ export interface LegacySavedView2d extends LegacySavedViewBase {
   sectionDrawing?: SectionDrawingViewProps;
   sheetProps?: SheetProps;
   sheetAttachments?: Id64Array;
+  modelExtents?: Range3dProps;
 }
 
 export interface LegacySavedViewBase {


### PR DESCRIPTION
Change modelExtents to be part of the 2d views & make optionally undefined. Should not ever be set to { }.