### PR TITLE
Fix captureSavedViewData failing with blank iModel connections

### DIFF
--- a/packages/saved-views-react/CHANGELOG.md
+++ b/packages/saved-views-react/CHANGELOG.md
@@ -45,6 +45,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixes
 
+* Fix `captureSavedViewData` failing with blank iModel connections
 * Replace usage of internal iTwin.js API with public alternative
 
 ## [0.6.0](https://github.com/iTwin/saved-views/tree/react-v0.6.0/packages/saved-views-react/) - 2024-07-22

--- a/packages/saved-views-react/src/captureSavedViewData.ts
+++ b/packages/saved-views-react/src/captureSavedViewData.ts
@@ -218,6 +218,10 @@ function toDegrees(angle: AngleProps): number | undefined {
 }
 
 export async function getMissingModels(iModel: IModelConnection, knownModels: Set<string>): Promise<string[]> {
+  if (iModel.isBlank) {
+    return [];
+  }
+
   const allModels = await getAllModels(iModel);
   return allModels.map(({ id }) => id).filter((model) => !knownModels.has(model));
 }
@@ -240,6 +244,10 @@ async function getAllModels(iModel: IModelConnection): Promise<Array<{ id: strin
 }
 
 export async function getMissingCategories(iModel: IModelConnection, knownCategories: Set<string>): Promise<Id64Array> {
+  if (iModel.isBlank) {
+    return [];
+  }
+
   const allCategories = await getAllCategories(iModel);
   return allCategories.map(({ id }) => id).filter((category) => !knownCategories.has(category));
 }

--- a/packages/test-app-frontend/src/App/App.tsx
+++ b/packages/test-app-frontend/src/App/App.tsx
@@ -72,6 +72,7 @@ function Main(): ReactElement {
             <Route path=":iTwinId" element={<IModelBrowser />} />
           </Route>
           <Route path="open-imodel/:iTwinId/:iModelId" element={<OpenIModel iTwinJsApp={iTwinJsApp} />} />
+          <Route path="open-blank-connection" element={<OpenBlankConnection iTwinJsApp={iTwinJsApp} />} />
         </Route>
       </Routes>
     </>
@@ -188,4 +189,16 @@ function OpenIModel(props: OpenIModelProps): ReactElement | null {
   }
 
   return <props.iTwinJsApp iTwinId={iTwinId} iModelId={iModelId} />;
+}
+
+interface OpenBlankConnectionProps {
+  iTwinJsApp: typeof ITwinJsApp | undefined;
+}
+
+function OpenBlankConnection(props: OpenBlankConnectionProps): ReactElement {
+  if (props.iTwinJsApp === undefined) {
+    return <LoadingScreen>Initializing...</LoadingScreen>;
+  }
+
+  return <props.iTwinJsApp iTwinId="" iModelId="" />;
 }

--- a/packages/test-app-frontend/src/App/ITwinJsApp/ITwinJsApp.tsx
+++ b/packages/test-app-frontend/src/App/ITwinJsApp/ITwinJsApp.tsx
@@ -3,11 +3,11 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 import {
-  BentleyCloudRpcManager, BentleyCloudRpcParams, IModelReadRpcInterface, IModelTileRpcInterface,
+  BentleyCloudRpcManager, BentleyCloudRpcParams, Cartographic, IModelReadRpcInterface, IModelTileRpcInterface,
   type AuthorizationClient,
 } from "@itwin/core-common";
 import {
-  CheckpointConnection, IModelApp, type IModelConnection, type Viewport, type ViewState,
+  BlankConnection, CheckpointConnection, IModelApp, type IModelConnection, type Viewport, type ViewState,
 } from "@itwin/core-frontend";
 import { ITwinLocalization } from "@itwin/core-i18n";
 import { UiCore } from "@itwin/core-react";
@@ -96,7 +96,17 @@ function useIModel(
       IModelApp.authorizationClient = authorizationClient;
 
       let disposed = false;
-      const iModelPromise = CheckpointConnection.openRemote(iTwinId, iModelId);
+      const iModelPromise = iModelId === ""
+        ? (
+          Promise.resolve(
+            BlankConnection.create({
+              name: "saved-viws-test-app-blank-connection",
+              location: Cartographic.createZero(),
+              extents: { low: { x: 0.0, y: 0.0, z: 0.0 }, high: { x: 1.0, y: 1.0, z: 1.0 } },
+            }),
+          )
+        )
+        : CheckpointConnection.openRemote(iTwinId, iModelId);
       void (async () => {
         try {
           const openedIModel = await iModelPromise;

--- a/packages/test-app-frontend/src/App/ITwinJsApp/SavedViewsWidget.tsx
+++ b/packages/test-app-frontend/src/App/ITwinJsApp/SavedViewsWidget.tsx
@@ -70,6 +70,19 @@ export function SavedViewsWidget(props: SavedViewsWidgetProps): ReactElement {
     return <LoadingScreen>Loading saved views...</LoadingScreen>;
   }
 
+  const handleCaptureSavedView = async () => {
+    try {
+      const savedViewData = await captureSavedViewData({ viewport: props.viewport });
+      toaster.positive("Captured saved view. See output in console.");
+      // eslint-disable-next-line no-console
+      console.log(savedViewData);
+    } catch (error) {
+      toaster.negative("Failed to capture saved view.");
+      // eslint-disable-next-line no-console
+      console.error(error);
+    }
+  };
+
   const handleCreateView = async () => {
     const savedViewData = await captureSavedViewData({ viewport: props.viewport });
     const savedViewId = await savedViews.createSavedView({ displayName: "0 Saved View Name" }, savedViewData);
@@ -124,7 +137,14 @@ export function SavedViewsWidget(props: SavedViewsWidgetProps): ReactElement {
       alignContent: "start",
       minHeight: 0,
     }}>
-      <div style={{ display: "flex", gap: "var(--iui-size-s)", paddingTop: "var(--iui-size-s)", alignItems: "center" }}>
+      <div style={{
+        display: "flex",
+        flexWrap: "wrap",
+        gap: "var(--iui-size-s)",
+        paddingTop: "var(--iui-size-s)",
+        alignItems: "center",
+      }}>
+        <Button onClick={handleCaptureSavedView}>Capture saved view</Button>
         <Button onClick={handleCreateView}>Create saved view</Button>
         <Button onClick={() => savedViews.createGroup("0 Group")}>Create group</Button>
         {operationsInProgress > 0 && "Updating saved views..."}

--- a/packages/test-app-frontend/src/App/imodel-browser/ITwinBrowser.tsx
+++ b/packages/test-app-frontend/src/App/imodel-browser/ITwinBrowser.tsx
@@ -2,7 +2,7 @@
 * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
-import { SvgProject } from "@itwin/itwinui-icons-react";
+import { SvgImodelHollow, SvgProject } from "@itwin/itwinui-icons-react";
 import { FluidGrid, PageLayout } from "@itwin/itwinui-layouts-react";
 import { Surface, Text, Tile } from "@itwin/itwinui-react";
 import { type ReactElement } from "react";
@@ -27,20 +27,38 @@ export function ITwinBrowser(): ReactElement {
     { authorizationClient },
   );
 
+  const navigate = useNavigate();
+
   return (
     <PageLayout.Content padded>
       <div style={{ display: "grid", gap: "var(--iui-size-xl)" }}>
-        <Surface style={{ padding: "var(--iui-size-l)" }}>
-          <div style={{ display: "grid", gap: "var(--iui-size-m)" }}>
-            <Text variant="title">Recent</Text>
-            <Paginator
-              initialUrl={applyUrlPrefix("https://api.bentley.com/itwins/recents?subclass=Project&$top=5")}
-              fetch={fetchITwins}
-            >
-              {(result) => <ITwinTileGrid iTwins={result.iTwins} />}
-            </Paginator>
-          </div>
-        </Surface>
+        <div style={{ display: "grid", grid: "1fr / auto 1fr" }}>
+          <Tile.Wrapper style={{ margin: "var(--iui-size-l)", width: "calc(10 * var(--iui-size-l))" }}>
+            <Tile.ThumbnailArea style={{ height: "calc(5 * var(--iui-size-l))" }}>
+              <Tile.ThumbnailPicture>
+                <SvgImodelHollow />
+              </Tile.ThumbnailPicture>
+            </Tile.ThumbnailArea>
+            <Tile.Name>
+              <Tile.NameLabel>
+                <Tile.Action onClick={() => navigate("/itwinjs/open-blank-connection")}>
+                  Open  blank connection
+                </Tile.Action>
+              </Tile.NameLabel>
+            </Tile.Name>
+          </Tile.Wrapper>
+          <Surface style={{ padding: "var(--iui-size-l)" }}>
+            <div style={{ display: "grid", gap: "var(--iui-size-m)" }}>
+              <Text variant="title">Recent</Text>
+              <Paginator
+                initialUrl={applyUrlPrefix("https://api.bentley.com/itwins/recents?subclass=Project&$top=5")}
+                fetch={fetchITwins}
+              >
+                {(result) => <ITwinTileGrid iTwins={result.iTwins} />}
+              </Paginator>
+            </div>
+          </Surface>
+        </div>
         <div style={{ display: "grid", gap: "var(--iui-size-m)" }}>
           <Text variant="title">All iTwins</Text>
           <Paginator


### PR DESCRIPTION
### Fixes

* Fix `captureSavedViewData` failing with blank iModel connections

### Other changes

* Test app enhancements
  * Add option to open blank iModel connection
  * Add button to test `captureSavedViewData` functionality