### PR TITLE
Enhance applySavedView API

### DIFF
--- a/packages/saved-views-client/README.md
+++ b/packages/saved-views-client/README.md
@@ -10,8 +10,7 @@ This package hosts client-side code and TypeScript types for interacting with [i
 import { ITwinSavedViewsClient } from "@itwin/saved-views-client";
 
 const client = new ITwinSavedViewsClient({
-  // auth_token should have access to savedviews:read and savedviews:modify OIDC scopes
-  getAccessToken: async () => "<auth_token>",
+  getAccessToken: async () => "<itwin_platform_auth_token>",
 });
 
 const { savedView } = await client.getSavedViewMinimal({ savedViewId: "<saved_view_id>" });

--- a/packages/saved-views-client/src/client/ITwinSavedViewsClient.ts
+++ b/packages/saved-views-client/src/client/ITwinSavedViewsClient.ts
@@ -17,10 +17,7 @@ export interface ITwinSavedViewsClientParams {
   /** @default "https://api.bentley.com/savedviews"  */
   baseUrl?: string;
 
-  /**
-   * Authorization token that grants access to iTwin Saved Views API. The token should be valid for `savedviews:read`
-   * and `savedviews:modify` OIDC scopes.
-   */
+  /** Authorization token that grants access to iTwin Platform API. */
   getAccessToken: () => Promise<string>;
 }
 

--- a/packages/saved-views-react/CHANGELOG.md
+++ b/packages/saved-views-react/CHANGELOG.md
@@ -14,6 +14,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
   * Move `viewData` and `extensions` properties to `SavedViewData` type
     * Type of `viewData` has changed and definition has moved to `@itwin/saved-views-react`
   * Change type of `creationTime` and `lastModified` properties to `Date | undefined`
+* Make `applySavedView` settings easier to understand
+  * Remove `"reset"` from `ApplyStrategy` union, instead make `"clear"` a valid value for `emphasis` and `perModelCategoryVisibility` properties
+  * Remove `all` property which set default `ApplyStrategy` of all settings
+  * Update documentation
 * `useSavedViews` hook rework
   * No longer implements optimistic behaviour
   * Lazily loads Saved View thumbnails and `SavedViewData`
@@ -42,6 +46,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
   * Add `thumbnail` prop
   * Thumbnails that were specified as image URLs now need to be explicitly passed as `<img src={url} />`
   * `onRename` callback will no longer send `undefined` for `newName` argument
+
+### Minor changes
+
+* `applySavedView` enhancements
+  * Accept custom `viewChangeOptions` that the function will internally pass through to `viewport.changeView` call
+  * Add `camera` setting that controls how camera data is applied. Allow supplying a custom `ViewPose` or ignoring Saved View data to keep the camera in place.
 
 ### Fixes
 

--- a/packages/saved-views-react/README.md
+++ b/packages/saved-views-react/README.md
@@ -8,24 +8,22 @@ A collection of utilities and React components for building iTwin applications t
 
 ### [captureSavedViewData](./src/captureSavedViewData.ts)
 
-Captures current viewport state into serializable format. The returned data can later be used to restore viewport's view.
+Capture current viewport state into serializable format. You can use this data later to restore the view.
 
 ```ts
-const { viewData, extensions = [] } = await captureSavedViewData({ viewport });
-extensions.push(myCustomExtension(viewport));
+const { viewData, extensions } = await captureSavedViewData({ viewport });
 console.log({ viewData, extensions }); /*
 {
   viewData: { itwin3dView: {...} },
   extensions: {
     { extensionName: "EmphasizeElements", data: "{...}" },
-    { extensionName: "MyCustomExtension", data: "my_custom_extension_data" },
   }
 } */
 ```
 
 ### [captureSavedViewThumbnail](./src/captureSavedViewThumbnail.ts)
 
-Generates Saved View thumbnail based on what is currently displayed on the viewport.
+Generate Saved View thumbnail based on what is currently displayed on the viewport.
 
 ```ts
 const thumbnail = captureSavedViewThumbnail(viewport);
@@ -34,24 +32,12 @@ console.log(thumbnail); // "data:image/png;base64,iVBORw0KGoAAAANSUhEUg..."
 
 ### [applySavedView](./src/applySavedView.ts)
 
-Updates viewport state to match captured Saved View.
+Update viewport state to match captured Saved View.
 
 ```ts
 // Capture viewport state
 const savedViewData = await captureSavedViewData({ viewport });
 // Restore viewport state
-await applySavedView(iModel, viewport, savedViewData);
-```
-
-### [createViewState](./src/createViewState.ts)
-
-Creates ViewState object out of Saved View data. It provides a lower-level access to view data for advanced use.
-
-```ts
-const viewState = await createViewState(iModel, savedViewData.viewData);
-await applySavedView(iModel, viewport, savedViewData, { viewState });
-
-// The two lines above are equivalent to
 await applySavedView(iModel, viewport, savedViewData);
 ```
 
@@ -99,8 +85,7 @@ export function SavedViewsWidget(props) {
 import { useSavedViews, ITwinSavedViewsClient } from "@itwin/saved-views-react";
 
 const client = new ITwinSavedViewsClient({
-  // auth_token should have access to savedviews:read and savedviews:modify OIDC scopes
-  getAccessToken: async () => "auth_token",
+  getAccessToken: async () => "itwin_platform_auth_token",
 });
 
 export function SavedViewsWidget(props) {

--- a/packages/saved-views-react/src/SavedViewsClient/ITwinSavedViewsClient.ts
+++ b/packages/saved-views-react/src/SavedViewsClient/ITwinSavedViewsClient.ts
@@ -15,10 +15,7 @@ import type {
 } from "./SavedViewsClient.js";
 
 interface ITwinSavedViewsClientParams {
-  /**
-   * Authorization token that grants access to iTwin Saved Views API. The token should be valid for `savedviews:read`
-   * and `savedviews:modify` OIDC scopes.
-  */
+  /** Authorization token that grants access to iTwin Platform API. */
   getAccessToken: () => Promise<string>;
 
   /** @default "https://api.bentley.com/savedviews" */

--- a/packages/saved-views-react/src/captureSavedViewThumbnail.ts
+++ b/packages/saved-views-react/src/captureSavedViewThumbnail.ts
@@ -8,13 +8,17 @@ import { Point2d } from "@itwin/core-geometry";
 
 /**
  * Generates Saved View thumbnail based on what is currently displayed on the {@linkcode viewport}.
- * @returns base64-encoded URL string
- * 
+ * @returns base64-encoded URL string, or `undefined` if the thumbnail could not be generated
+ *
  * @example
  * const thumbnail = captureSavedViewThumbnail(viewport);
  * console.log(thumbnail); // "data:image/png;base64,iVBORw0KGoAAAANSUhEUg..."
  */
-export function captureSavedViewThumbnail(viewport: Viewport, width = 280, height = 200): string | undefined {
+export function captureSavedViewThumbnail(
+  viewport: Viewport,
+  width = 280,
+  height = 200,
+): string | undefined {
   const thumbnail = getThumbnail(viewport, width, height);
   if (!thumbnail) {
     return undefined;
@@ -27,16 +31,17 @@ export function captureSavedViewThumbnail(viewport: Viewport, width = 280, heigh
 function getThumbnail(vp: Viewport, width: number, height: number): ImageBuffer | undefined {
   const size = new Point2d(width, height);
 
-  // Passing in vp.target.viewRect instead of vp.viewRect because currently vp.viewRect is not updated correctly in some
-  // cases when a new dialog is created. The bottom property would be 2px higher than the renderRect in readImageBuffer
-  // which caused the method to return undefined. vp.target.viewRect allows us to have the correct dimensions when
-  // creating the thumbnail.
+  // Passing in vp.target.viewRect instead of vp.viewRect because currently vp.viewRect
+  // is not updated correctly in some cases when a new dialog is created. The bottom
+  // property would be 2px higher than the renderRect in readImageBuffer which
+  // caused the method to return undefined. vp.target.viewRect allows us to have
+  // the correct dimensions when creating the thumbnail.
   const thumbnail = vp.readImageBuffer({ rect: getCenteredViewRect(vp.target.viewRect), size });
   if (thumbnail) {
     return thumbnail;
   }
 
-  // Since using vp.target.viewRect while creating thumbnail returns undefined for some, we switch back to using
-  // vp.viewRect
+  // Since using vp.target.viewRect while creating thumbnail returns undefined
+  // for some, we switch back to using vp.viewRect
   return vp.readImageBuffer({ rect: getCenteredViewRect(vp.viewRect), size });
 }

--- a/packages/saved-views-react/src/createViewState.ts
+++ b/packages/saved-views-react/src/createViewState.ts
@@ -3,22 +3,23 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 import {
-  Camera, type CodeProps, type SpatialViewDefinitionProps, type ViewDefinition2dProps, type ViewStateProps,
+  Camera, type CodeProps, type SpatialViewDefinitionProps, type ViewDefinition2dProps,
+  type ViewStateProps,
 } from "@itwin/core-common";
 import {
   DrawingViewState, SheetViewState, SpatialViewState, type IModelConnection, type ViewState,
 } from "@itwin/core-frontend";
 import type { ViewITwin3d, ViewITwinDrawing, ViewITwinSheet } from "@itwin/saved-views-client";
 
-import { getMissingCategories, getMissingModels } from "./captureSavedViewData.js";
+import { queryMissingCategories, queryMissingModels } from "./captureSavedViewData.js";
 import type { ViewData } from "./SavedView.js";
 import { extractClipVectors } from "./translation/clipVectorsExtractor.js";
 import { extractDisplayStyle, extractDisplayStyle3d } from "./translation/displayStyleExtractor.js";
 
 export interface ViewStateCreateSettings {
   /**
-   * Normally {@link createViewState} function invokes and awaits {@linkcode ViewState.load} method before returning.
-   * You may skip this step if you intend to perform it later.
+   * Normally {@link createViewState} function invokes and awaits {@linkcode ViewState.load}
+   * method before returning. You may skip this step if you intend to perform it later.
    * @default false
    *
    * @example
@@ -29,15 +30,16 @@ export interface ViewStateCreateSettings {
   skipViewStateLoad?: boolean | undefined;
 
   /**
-   * How to handle visibility of models and categories that exist in iModel but are not captured in Saved View data.
+   * How to handle visibility of models and categories that exist in iModel but
+   * not captured in Saved View data.
    * @default "hidden"
    */
   modelAndCategoryVisibilityFallback?: "visible" | "hidden" | undefined;
 }
 
 /**
- * Creates {@link ViewState} object out of Saved View data. It provides a lower-level access to view data for advanced
- * use.
+ * Creates {@link ViewState} object out of Saved View data. It provides a lower-level
+ * access to view data for advanced use.
  *
  * @example
  * const viewState = await createViewState(iModel, savedViewData.viewData);
@@ -312,8 +314,8 @@ async function unhideNewModelsAndCategories(
     }
 
     const [visibleCategories, visibleModels] = await Promise.all([
-      getMissingCategories(iModel, new Set(viewData.categories.disabled)),
-      getMissingModels(iModel, new Set(viewData.models.disabled)),
+      queryMissingCategories(iModel, new Set(viewData.categories.disabled)),
+      queryMissingModels(iModel, new Set(viewData.models.disabled)),
     ]);
 
     viewState.categorySelector.addCategories(visibleCategories);
@@ -325,6 +327,9 @@ async function unhideNewModelsAndCategories(
     return;
   }
 
-  const visibleCategories = await getMissingCategories(iModel, new Set(viewData.categories.disabled));
+  const visibleCategories = await queryMissingCategories(
+    iModel,
+    new Set(viewData.categories.disabled),
+  );
   viewState.categorySelector.addCategories(visibleCategories);
 }

--- a/packages/test-app-frontend/.env
+++ b/packages/test-app-frontend/.env
@@ -1,18 +1,8 @@
 # Create a .env.local file in this directory with the following content:
 
-# OAuth 2.0 application client ID. Register your own at https://developer.bentley.com/register/ with these settings:
-#   - API associations:
-#     - Administration
-#       - users:read
-#     - Digital Twin Management:
-#       - itwins:read
-#       - imodels:read
-#       - savedviews:read
-#       - savedviews:modify
-#     - Visualization:
-#       - imodelaccess:read
-#   - Application type:
-#     - SPA (Single web page app)
+# OAuth 2.0 application client ID. Register your own at https://developer.bentley.com/register/
+# with settings:
+#   - Application type: SPA
 #   - Redirect URIs:
 #     - http://localhost:7948/auth/callback
 #     - http://localhost:7948/auth/silent

--- a/packages/test-app-frontend/src/App/App.tsx
+++ b/packages/test-app-frontend/src/App/App.tsx
@@ -39,7 +39,7 @@ export function App(): ReactElement {
           redirectUri="/auth/callback"
           silentRedirectUri="/auth/silent"
           postLogoutRedirectUri="/"
-          scope="itwins:read users:read savedviews:modify savedviews:read imodels:read imodelaccess:read"
+          scope="itwin-platform"
         >
           <PageLayout>
             <PageLayout.Header>


### PR DESCRIPTION
Rework `applySavedView` settings interface to make it easier to understand.

Initially I designed it around the idea of extensions having three three operations: save, apply, and reset. While this system worked well for some applications, this confined the interface to a narrow applicability space and burdened users with a mental model that didn't necessarily match their expectations. This change is a step towards rethinking what it means to "apply a saved view", and making built-in `EmphasizeElements` and `PerModelCategoryVisibility` extensions first-class concepts of `saved-views-react`.

### Breaking changes

* Make `applySavedView` settings easier to understand
  * Remove `"reset"` from `ApplyStrategy` union, instead make `"clear"` a valid value for `emphasis` and `perModelCategoryVisibility` properties
  * Remove `all` property which set default `ApplyStrategy` of all settings
  * Update documentation

### Minor changes

* `applySavedView` enhancements
  * Accept custom `viewChangeOptions` that the function will internally pass through to `viewport.changeView` call
  * Add `camera` setting that controls how camera data is applied. Allow supplying a custom `ViewPose` or ignoring Saved View data to keep the camera in place.

### Other

- Improve documentation
  - Add precision, change wording, and simplify examples
  - Remove mentions of `savedviews:read` and `savedviews:modify` because they have been superseded by `itwin-platform` scope
- Reformat code where it exceeds 100 columns in width, down from 120
  - Start breaking comments into new lines after reaching 80th column
- Simplify `executeQuery` use by making it return a flat list of ids