### PR TITLE
Add overrides for emphasizeElements extension when apply/capturing saved view

### DIFF
--- a/packages/saved-views-react/src/captureSavedViewData.ts
+++ b/packages/saved-views-react/src/captureSavedViewData.ts
@@ -13,7 +13,7 @@ import type { ViewITwinDrawing, ViewYawPitchRoll } from "@itwin/saved-views-clie
 import type {
   ITwin3dViewData, ITwinDrawingdata, ITwinSheetData, SavedViewData, ViewData,
 } from "./SavedView.js";
-import { ExtensionHandler, extensionHandlers } from "./translation/SavedViewsExtensionHandlers.js";
+import { ExtensionHandler, extensionHandlers, type DefaultExtensionHandlersCaptureOverrides } from "./translation/SavedViewsExtensionHandlers.js";
 import { extractClipVectorsFromLegacy } from "./translation/clipVectorsLegacyExtractor.js";
 import {
   extractDisplayStyle2dFromLegacy, extractDisplayStyle3dFromLegacy,
@@ -34,6 +34,11 @@ interface CaptureSavedViewDataArgs {
    * @default false
    */
   omitPerModelCategoryVisibility?: boolean | undefined;
+
+  /**
+   * Overrides for the capture function of default extension handlers .
+   */
+  overrides?: DefaultExtensionHandlersCaptureOverrides;
 }
 
 /**
@@ -53,11 +58,18 @@ interface CaptureSavedViewDataArgs {
 export async function captureSavedViewData(args: CaptureSavedViewDataArgs): Promise<SavedViewData> {
   const extensions: ExtensionHandler[] = [];
   if (!args.omitEmphasis) {
-    extensions.push(extensionHandlers.emphasizeElements);
+    extensions.push({
+        ...extensionHandlers.emphasizeElements,
+        capture: args.overrides?.emphasizeElements?.capture ?? extensionHandlers.emphasizeElements.capture,
+      },
+    );
   }
 
   if (!args.omitPerModelCategoryVisibility) {
-    extensions.push(extensionHandlers.perModelCategoryVisibility);
+    extensions.push({
+      ...extensionHandlers.perModelCategoryVisibility,
+        capture: args.overrides?.perModelCategoryVisibility?.capture ?? extensionHandlers.perModelCategoryVisibility.capture,
+    });
   }
 
   return {

--- a/packages/saved-views-react/src/translation/SavedViewsExtensionHandlers.ts
+++ b/packages/saved-views-react/src/translation/SavedViewsExtensionHandlers.ts
@@ -1,10 +1,17 @@
 /*---------------------------------------------------------------------------------------------
-* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
-* See LICENSE.md in the project root for license terms and full copyright notice.
-*--------------------------------------------------------------------------------------------*/
-import { EmphasizeElements, PerModelCategoryVisibility, type Viewport } from "@itwin/core-frontend";
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+import {
+  EmphasizeElements,
+  PerModelCategoryVisibility,
+  type Viewport,
+} from "@itwin/core-frontend";
 
-import { extractEmphasizeElements, extractPerModelCategoryVisibility } from "./extensionExtractor.js";
+import {
+  extractEmphasizeElements,
+  extractPerModelCategoryVisibility,
+} from "./extensionExtractor.js";
 import type { PerModelCategoryVisibilityProps } from "./SavedViewTypes.js";
 
 export interface ExtensionHandler {
@@ -12,6 +19,16 @@ export interface ExtensionHandler {
   apply: (extensionData: string, viewport: Viewport) => void;
   reset: (viewport: Viewport) => void;
   capture: (viewport: Viewport) => string | undefined;
+}
+
+export interface DefaultExtensionHandlersApplyOverrides {
+  emphasizeElements?: Partial<Pick<ExtensionHandler, "apply" | "reset" >>;
+  perModelCategoryVisibility?: Partial<Pick<ExtensionHandler, "apply" | "reset" >>;
+}
+
+export interface DefaultExtensionHandlersCaptureOverrides {
+  emphasizeElements?: Partial<Pick<ExtensionHandler, "capture">>;
+  perModelCategoryVisibility?: Partial<Pick<ExtensionHandler, "capture">>;
 }
 
 export const extensionHandlers = {


### PR DESCRIPTION
Currently, for the default extensions EmphasizedElements and perModelCategoryVisibility, when capturing or applying a saved view, there is no way for a user to override the data that is passed in the extension other than modifying the viewport itself.

## Minor Changes
- Add new two types DefaultExtensionHandlersApplyOverrides, DefaultExtensionHandlersCaptureOverrides that allows user to override the apply/reset function, and capture function respectively for both EmphasizeElements and perModelCategoryVisibility.
- Modify captureSavedViewData and applySavedView functions to use override functions if provided.