### PR TITLE
Update react to always clear emphasizeElements and perModelCatVis

### DIFF
--- a/.changeset/grumpy-dingos-dress.md
+++ b/.changeset/grumpy-dingos-dress.md
@@ -1,0 +1,5 @@
+---
+"@itwin/saved-views-react": patch
+---
+
+Clear emphasizeElements and perModelCatVis everytime you apply a view (before the view is applied) instead of just if the saved view has that extension.

--- a/packages/saved-views-react/CHANGELOG.md
+++ b/packages/saved-views-react/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.9.1
+
+### Patch Changes
+
+### [0.9.1](https://github.com/iTwin/saved-views/tree/v0.9.1-react/packages/saved-views-react) - 2025-02-25
+
+- Update react to always clear `emphasizeElements` and `perModelCategoryVisibility` anytime you apply a view
+
 ## 0.9.0
 
 ### Minor Changes

--- a/packages/saved-views-react/package.json
+++ b/packages/saved-views-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itwin/saved-views-react",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/saved-views-react/src/applySavedView.ts
+++ b/packages/saved-views-react/src/applySavedView.ts
@@ -118,16 +118,21 @@ export async function applySavedView(
     viewport.changeView(viewState, settings.viewChangeOptions);
   }
 
+  // Reset each extension even if it's not present in the saved view data
+  if (settings.emphasis !== "keep") {
+    overrides?.emphasizeElements?.reset
+      ? overrides?.emphasizeElements.reset(viewport)
+      : extensionHandlers.emphasizeElements.reset(viewport);
+  }
+  if (settings.perModelCategoryVisibility !== "keep") {
+    overrides?.perModelCategoryVisibility?.reset
+      ? overrides?.perModelCategoryVisibility.reset(viewport)
+      : extensionHandlers.perModelCategoryVisibility.reset(viewport);
+  }
+
   const extensions = findKnownExtensions(savedViewData.extensions ?? []);
   if (extensions.emphasis) {
     const override = overrides?.emphasizeElements;
-
-    if (settings.emphasis !== "keep") {
-      override?.reset
-        ? override.reset(viewport)
-        : extensionHandlers.emphasizeElements.reset(viewport);
-    }
-
     if (settings.emphasis === "apply") {
       override?.apply
         ? override.apply(extensions.emphasis, viewport)
@@ -140,12 +145,6 @@ export async function applySavedView(
 
   if (extensions.perModelCategoryVisibility) {
     const override = overrides?.perModelCategoryVisibility;
-    if (settings.perModelCategoryVisibility !== "keep") {
-      override?.reset
-        ? override.reset(viewport)
-        : extensionHandlers.perModelCategoryVisibility.reset(viewport);
-    }
-
     if (settings.perModelCategoryVisibility === "apply") {
       override?.apply
         ? override.apply(extensions.perModelCategoryVisibility, viewport)

--- a/packages/saved-views-react/src/applySavedView.ts
+++ b/packages/saved-views-react/src/applySavedView.ts
@@ -118,21 +118,16 @@ export async function applySavedView(
     viewport.changeView(viewState, settings.viewChangeOptions);
   }
 
-  // Reset each extension even if it's not present in the saved view data
-  if (settings.emphasis !== "keep") {
-    overrides?.emphasizeElements?.reset
-      ? overrides?.emphasizeElements.reset(viewport)
-      : extensionHandlers.emphasizeElements.reset(viewport);
-  }
-  if (settings.perModelCategoryVisibility !== "keep") {
-    overrides?.perModelCategoryVisibility?.reset
-      ? overrides?.perModelCategoryVisibility.reset(viewport)
-      : extensionHandlers.perModelCategoryVisibility.reset(viewport);
-  }
-
   const extensions = findKnownExtensions(savedViewData.extensions ?? []);
   if (extensions.emphasis) {
     const override = overrides?.emphasizeElements;
+
+    if (settings.emphasis !== "keep") {
+      override?.reset
+        ? override.reset(viewport)
+        : extensionHandlers.emphasizeElements.reset(viewport);
+    }
+
     if (settings.emphasis === "apply") {
       override?.apply
         ? override.apply(extensions.emphasis, viewport)
@@ -145,6 +140,12 @@ export async function applySavedView(
 
   if (extensions.perModelCategoryVisibility) {
     const override = overrides?.perModelCategoryVisibility;
+    if (settings.perModelCategoryVisibility !== "keep") {
+      override?.reset
+        ? override.reset(viewport)
+        : extensionHandlers.perModelCategoryVisibility.reset(viewport);
+    }
+
     if (settings.perModelCategoryVisibility === "apply") {
       override?.apply
         ? override.apply(extensions.perModelCategoryVisibility, viewport)


### PR DESCRIPTION
Clear emphasizeElements and perModelCatVis everytime you apply a view (before the view is applied) instead of just if the saved view has that extension.