### PR TITLE
fix 'new content' apply mode when using mesh tiles

### DIFF
--- a/.changeset/fluffy-wings-train.md
+++ b/.changeset/fluffy-wings-train.md
@@ -1,0 +1,5 @@
+---
+"@itwin/saved-views-react": patch
+---
+
+fix new content apply mode when using mesh tiles

--- a/packages/saved-views-react/src/createViewState.ts
+++ b/packages/saved-views-react/src/createViewState.ts
@@ -468,7 +468,9 @@ async function unhideNewModelsAndCategories(
     ]);
 
     viewState.categorySelector.addCategories(visibleCategories);
-    viewState.modelSelector.addModels(visibleModels);
+    const modelSelector = viewState.modelSelector.clone();
+    modelSelector.addModels(visibleModels);
+    viewState.modelSelector = modelSelector;
     return;
   }
 


### PR DESCRIPTION
fixes an issue where when using mesh tiles if you set the apply mode as new content and apply a saved view new models won't show

related: [⚡saved-views-react@0.9.4-patch 🐛 saved views (new) - fix new content apply mode](https://bentleycs.visualstudio.com/beconnect/_git/TCDEAppService/pullrequest/523696)

since its not obvious why this fix would help, this github issue in itwin-graphics-backlog might help https://github.com/iTwin/itwin-graphics-backlog/issues/527

essentially, the setter for the viewState.modelSelector has an event that is important for mesh tiles to update the view and this is why merely running viewState.modelSelector.addModels is insufficient, because it won't trigger the event mesh tiles responds to