### PR TITLE
Remove content type header when request body is empty

### DIFF
--- a/.changeset/strong-things-hide.md
+++ b/.changeset/strong-things-hide.md
@@ -1,0 +1,5 @@
+---
+"@itwin/saved-views-client": patch
+---
+
+Remove content type header when request body is empty

--- a/packages/saved-views-client/src/client/ITwinSavedViewsClient.test.ts
+++ b/packages/saved-views-client/src/client/ITwinSavedViewsClient.test.ts
@@ -422,7 +422,7 @@ describe("ITwinSavedViewsClient", () => {
           ...args.headers,
         } : {
           Authorization: "test_auth_token",
-          ...args.headers
+          ...args.headers,
         },
         body: args.body,
       },

--- a/packages/saved-views-client/src/client/ITwinSavedViewsClient.test.ts
+++ b/packages/saved-views-client/src/client/ITwinSavedViewsClient.test.ts
@@ -416,10 +416,13 @@ describe("ITwinSavedViewsClient", () => {
       args.url,
       {
         method: args.method,
-        headers: {
+        headers: args.body ? {
           Authorization: "test_auth_token",
           "Content-Type": "application/json",
           ...args.headers,
+        } : {
+          Authorization: "test_auth_token",
+          ...args.headers
         },
         body: args.body,
       },

--- a/packages/saved-views-client/src/client/ITwinSavedViewsClient.ts
+++ b/packages/saved-views-client/src/client/ITwinSavedViewsClient.ts
@@ -35,10 +35,10 @@ export class ITwinSavedViewsClient implements SavedViewsClient {
     return callITwinApi({
       url: args.url,
       method: args.method,
-      headers: {
+      headers: args.body ? {
         "Content-Type": "application/json",
         ...args.headers,
-      },
+      } : args.headers,
       body: args.body,
       getAccessToken: this.getAccessToken,
       signal: args.signal,


### PR DESCRIPTION
Fixes the issue mentioned here: [Saved view deletion is not working](https://bentleycs.visualstudio.com/beconnect/_boards/board/t/Pineapple%20-%20iMVF/Backlog%20items?System.AssignedTo=%40me&workitem=1671334)

Due to the fastify v5 version bump, `DELETE` requests are no longer allowed to have `Content-Type: application/json` header and an empty body, which caused the delete requests to fail in QA. [Reference](https://fastify.dev/docs/v5.1.x/Guides/Migration-Guide-V5/#remove-support-for-delete-with-a-content-type-applicationjson-header-and-an-empty-body)

This change removes the `Content-Type: application/json` header from the request when the body is empty.