### PR TITLE
Heather/rework mod and cat vis fallback

### DIFF
--- a/.changeset/odd-places-stop.md
+++ b/.changeset/odd-places-stop.md
@@ -1,5 +1,5 @@
 ---
-"@itwin/saved-views-react": patch
+"@itwin/saved-views-react": major
 ---
 
 Change models and categories fallback setting option to seperate and further define settings for models and categories

--- a/.changeset/witty-ravens-sleep.md
+++ b/.changeset/witty-ravens-sleep.md
@@ -1,0 +1,5 @@
+---
+"@itwin/saved-views-react": patch
+---
+
+Change models and categories fallback setting option to seperate and further define settings for models and categories

--- a/packages/saved-views-react/src/applySavedView.ts
+++ b/packages/saved-views-react/src/applySavedView.ts
@@ -28,6 +28,7 @@ import type {
 import {
   createViewStateFromProps,
   createViewStateProps,
+  type ElementSettings,
 } from "./createViewState.js";
 import {
   extensionHandlers,
@@ -73,28 +74,19 @@ export interface ApplySavedViewSettings {
    */
   perModelCategoryVisibility?: ApplyStrategy | "clear" | undefined;
 
+  /**
+   * How to handle the visibility of models that exist in iModel,
+   * including those not captured in Saved View data.
+   * @default '{ enabled: "ignore", disabled: "ignore", other: "ignore" }'
+   */
+  models?: ElementSettings | undefined;
 
   /**
-   * How to handle the visibility of models that exist in iModel but
-   * are not captured in Saved View data.
-   * @default "apply-hidden"
+   * How to handle the visibility of categories that exist in iModel,
+   * including those not captured in Saved View data.
+   * @default '{ enabled: "ignore", disabled: "ignore", other: "ignore" }'
    */
-  models?: "apply-visible" | "apply-hidden" | "keep" | "reset" | undefined;
-
-  /**
-   * How to handle the visibility of categories that exist in iModel but
-   * are not captured in Saved View data.
-   * @default "apply-hidden"
-   */
-  categories?: "apply-visible" | "apply-hidden" | "keep" | "reset" | undefined;
-
-
-  /**
-   * How to handle visibility of models and categories that exist in iModel but
-   * are not captured in Saved View data.
-   * @default "hidden"
-   */
-  modelAndCategoryVisibilityFallback?: "visible" | "hidden" | undefined;
+  categories?: ElementSettings | undefined;
 
   /**
    * Options forwarded to {@link Viewport.changeView}.
@@ -114,7 +106,7 @@ async function createSeedViewStateProps(
   iModel: IModelConnection,
   viewport: Viewport,
   savedViewData: SavedViewData,
-  settings: ApplySavedViewSettings | undefined = {},
+  settings: ApplySavedViewSettings | undefined = {}
 ): Promise<ViewStateProps> {
   if (settings.viewState !== "keep") {
     return settings.viewState instanceof ViewState
@@ -187,13 +179,22 @@ async function applyViewStateProps(
   iModel: IModelConnection,
   viewport: Viewport,
   savedViewData: SavedViewData,
-  settings: ApplySavedViewSettings,
+  settings: ApplySavedViewSettings
 ): Promise<void> {
-  // We use "hidden" as the default value for modelAndCategoryVisibilityFallback
-  // because users expect modelSelector.enabled and categorySelector.enabled to
-  // act as exclusive whitelists when modelSelector.disabled or categorySelector.disabled
-  // arrays are empty, respectively.
-  const { models = "apply-hidden", categories = "apply-hidden" } = settings;
+  // We use {enabled: "ignore", disabled: "ignore", other: "ignore"} as the default values
+  // for models and categories because users expect modelSelector.enabled and
+  // categorySelector.enabled to act as exclusive whitelists when modelSelector.disabled
+  // or categorySelector.disabled arrays are empty, respectively.
+  const models: ElementSettings = {
+    enabled: settings.models?.enabled ?? "ignore",
+    disabled: settings.models?.disabled ?? "ignore",
+    other: settings.models?.other ?? "ignore",
+  };
+  const categories: ElementSettings = {
+    enabled: settings.categories?.enabled ?? "ignore",
+    disabled: settings.categories?.disabled ?? "ignore",
+    other: settings.categories?.other ?? "ignore",
+  };
   const viewState = await createViewStateFromProps(
     viewStateProps,
     iModel,

--- a/packages/saved-views-react/src/applySavedView.ts
+++ b/packages/saved-views-react/src/applySavedView.ts
@@ -28,7 +28,7 @@ import type {
 import {
   createViewStateFromProps,
   createViewStateProps,
-  type ElementSettings,
+  type ApplyVisibilitySettings,
 } from "./createViewState.js";
 import {
   extensionHandlers,
@@ -79,14 +79,14 @@ export interface ApplySavedViewSettings {
    * including those not captured in Saved View data.
    * @default '{ enabled: "ignore", disabled: "ignore", other: "ignore" }'
    */
-  models?: ElementSettings | undefined;
+  models?: ApplyVisibilitySettings | undefined;
 
   /**
    * How to handle the visibility of categories that exist in iModel,
    * including those not captured in Saved View data.
    * @default '{ enabled: "ignore", disabled: "ignore", other: "ignore" }'
    */
-  categories?: ElementSettings | undefined;
+  categories?: ApplyVisibilitySettings | undefined;
 
   /**
    * Options forwarded to {@link Viewport.changeView}.
@@ -185,12 +185,12 @@ async function applyViewStateProps(
   // for models and categories because users expect modelSelector.enabled and
   // categorySelector.enabled to act as exclusive whitelists when modelSelector.disabled
   // or categorySelector.disabled arrays are empty, respectively.
-  const models: ElementSettings = {
+  const models: ApplyVisibilitySettings = {
     enabled: settings.models?.enabled ?? "ignore",
     disabled: settings.models?.disabled ?? "ignore",
     other: settings.models?.other ?? "ignore",
   };
-  const categories: ElementSettings = {
+  const categories: ApplyVisibilitySettings = {
     enabled: settings.categories?.enabled ?? "ignore",
     disabled: settings.categories?.disabled ?? "ignore",
     other: settings.categories?.other ?? "ignore",

--- a/packages/saved-views-react/src/applySavedView.ts
+++ b/packages/saved-views-react/src/applySavedView.ts
@@ -73,6 +73,22 @@ export interface ApplySavedViewSettings {
    */
   perModelCategoryVisibility?: ApplyStrategy | "clear" | undefined;
 
+
+  /**
+   * How to handle the visibility of models that exist in iModel but
+   * are not captured in Saved View data.
+   * @default "apply-hidden"
+   */
+  models?: "apply-visible" | "apply-hidden" | "keep" | "reset" | undefined;
+
+  /**
+   * How to handle the visibility of categories that exist in iModel but
+   * are not captured in Saved View data.
+   * @default "apply-hidden"
+   */
+  categories?: "apply-visible" | "apply-hidden" | "keep" | "reset" | undefined;
+
+
   /**
    * How to handle visibility of models and categories that exist in iModel but
    * are not captured in Saved View data.
@@ -177,13 +193,14 @@ async function applyViewStateProps(
   // because users expect modelSelector.enabled and categorySelector.enabled to
   // act as exclusive whitelists when modelSelector.disabled or categorySelector.disabled
   // arrays are empty, respectively.
-  const { modelAndCategoryVisibilityFallback = "hidden" } = settings;
+  const { models = "apply-hidden", categories = "apply-hidden" } = settings;
   const viewState = await createViewStateFromProps(
     viewStateProps,
     iModel,
     savedViewData.viewData,
     {
-      modelAndCategoryVisibilityFallback,
+      models,
+      categories,
     },
   );
   viewport.changeView(viewState, settings.viewChangeOptions);

--- a/packages/saved-views-react/src/applySavedView.ts
+++ b/packages/saved-views-react/src/applySavedView.ts
@@ -106,7 +106,7 @@ async function createSeedViewStateProps(
   iModel: IModelConnection,
   viewport: Viewport,
   savedViewData: SavedViewData,
-  settings: ApplySavedViewSettings | undefined = {}
+  settings: ApplySavedViewSettings | undefined = {},
 ): Promise<ViewStateProps> {
   if (settings.viewState !== "keep") {
     return settings.viewState instanceof ViewState
@@ -179,7 +179,7 @@ async function applyViewStateProps(
   iModel: IModelConnection,
   viewport: Viewport,
   savedViewData: SavedViewData,
-  settings: ApplySavedViewSettings
+  settings: ApplySavedViewSettings,
 ): Promise<void> {
   // We use {enabled: "ignore", disabled: "ignore", other: "ignore"} as the default values
   // for models and categories because users expect modelSelector.enabled and

--- a/packages/saved-views-react/src/captureSavedViewData.ts
+++ b/packages/saved-views-react/src/captureSavedViewData.ts
@@ -240,13 +240,16 @@ function toDegrees(angle: AngleProps): number | undefined {
 
 export async function queryMissingModels(
   iModel: IModelConnection,
-  knownModels: Set<string>,
+  knownModels?: Set<string>,
 ): Promise<string[]> {
   if (iModel.isBlank) {
     return [];
   }
 
   const allModels = await queryAllSpatiallyLocatedModels(iModel);
+  if (!knownModels || knownModels.size === 0) {
+    return allModels;
+  }
   return allModels.filter((modelId) => !knownModels.has(modelId));
 }
 
@@ -271,13 +274,16 @@ export async function queryAllSpatiallyLocatedModels(iModel: IModelConnection): 
 
 export async function queryMissingCategories(
   iModel: IModelConnection,
-  knownCategories: Set<string>,
+  knownCategories?: Set<string>,
 ): Promise<Id64Array> {
   if (iModel.isBlank) {
     return [];
   }
 
   const allCategories = await queryAllCategories(iModel);
+  if (!knownCategories || knownCategories.size === 0) {
+    return allCategories;
+  }
   return allCategories.filter((categoryId) => !knownCategories.has(categoryId));
 }
 

--- a/packages/saved-views-react/src/createViewState.ts
+++ b/packages/saved-views-react/src/createViewState.ts
@@ -99,7 +99,7 @@ export interface ViewStateCreateSettings {
  */
 export async function createViewStateProps(
   iModel: IModelConnection,
-  viewData: ViewData
+  viewData: ViewData,
 ): Promise<ViewStateProps> {
   const viewStateProps = await createViewStatePropsVariant(iModel, viewData);
   return viewStateProps;
@@ -109,7 +109,7 @@ async function applyViewStateOptions(
   viewState: ViewState,
   iModel: IModelConnection,
   viewData: ViewData,
-  settings: ViewStateCreateSettings = {}
+  settings: ViewStateCreateSettings = {},
 ) {
   await applyModelSettings(iModel, viewState, viewData, settings.models);
   await applyCategorySettings(iModel, viewState, viewData, settings.categories);
@@ -506,7 +506,7 @@ async function applyModelSettings(
         new Set([
           ...(viewData.models?.disabled ?? []),
           ...(viewData.models?.enabled ?? []),
-        ])
+        ]),
       );
       if (settings?.other === "show") {
         addModels.push(...otherModels);
@@ -552,7 +552,7 @@ async function applyCategorySettings(
       new Set([
         ...(viewData.categories?.disabled ?? []),
         ...(viewData.categories?.enabled ?? []),
-      ])
+      ]),
     );
     if (settings?.other === "show") {
       addCategories.push(...otherCategories);

--- a/packages/saved-views-react/src/createViewState.ts
+++ b/packages/saved-views-react/src/createViewState.ts
@@ -42,7 +42,7 @@ import { Id64Array } from "@itwin/core-bentley";
  *
  * @default '{ enabled: "ignore", disabled: "ignore", other: "ignore" }'
  */
-export interface ElementSettings {
+export interface ApplyVisibilitySettings {
   enabled?: ShowStrategy | undefined;
   disabled?: ShowStrategy | undefined;
   other?: ShowStrategy | undefined;
@@ -72,16 +72,24 @@ export interface ViewStateCreateSettings {
   /**
    * How to handle the visibility of models that exist in iModel,
    * including those not captured in Saved View data.
+   * Settings for how to handle the visibility of models in iModel.
+   *   * `enabled` – Enabled is the set of enabled models that are stored in the saved view. Default is ignore.
+   *   * `disabled` – Disabled is the set of disabled models that are stored in the saved view. Default is ignore.
+   *   * `other` – Other is the set of models that are not stored in the saved view. Default is ignore.
    * @default '{ enabled: "ignore", disabled: "ignore", other: "ignore" }'
    */
-  models?: ElementSettings | undefined;
+  models?: ApplyVisibilitySettings | undefined;
 
   /**
    * How to handle the visibility of categories that exist in iModel,
    * including those not captured in Saved View data.
+   * Settings for how to handle the visibility of categories in iModel.
+   *   * `enabled` – Enabled is the set of enabled categories that are stored in the saved view. Default is ignore.
+   *   * `disabled` – Disabled is the set of disabled categories that are stored in the saved view. Default is ignore.
+   *   * `other` – Other is the set of categories that are not stored in the saved view. Default is ignore.
    * @default '{ enabled: "ignore", disabled: "ignore", other: "ignore" }'
    */
-  categories?: ElementSettings | undefined;
+  categories?: ApplyVisibilitySettings | undefined;
 }
 
 /**
@@ -477,11 +485,20 @@ function cloneCode({ spec, scope, value }: CodeProps): CodeProps {
   return { spec, scope, value };
 }
 
+/**
+ * Apply the model settings to the view state.
+ * This function modifies the model selector of the view state based on the provided settings.
+ * @param iModel The current IModelConnection.
+ * @param viewState The view state to modify.
+ * @param viewData The view data containing the lists of enabled and disabled models that will be applied.
+ * @param settings The settings for how to handle the visibility of enabled, disabled, and other model lists. Default is 'ignore' for all.
+ * @returns A promise that resolves when the model settings have been applied.
+ */
 async function applyModelSettings(
   iModel: IModelConnection,
   viewState: ViewState,
   viewData: ViewData,
-  settings?: ElementSettings,
+  settings?: ApplyVisibilitySettings,
 ): Promise<void> {
   if (viewData.type === "iTwin3d") {
     if (!viewState.isSpatialView()) {
@@ -528,11 +545,20 @@ async function applyModelSettings(
   }
 }
 
+/**
+ * Apply the category settings to the view state.
+ * This function modifies the category selector of the view state based on the provided settings.
+ * @param iModel The current IModelConnection.
+ * @param viewState The view state to modify.
+ * @param viewData The view data containing the lists of enabled and disabled categories that will be applied.
+ * @param settings The settings for how to handle the visibility of enabled, disabled, and other category lists. Default is 'ignore' for all.
+ * @returns A promise that resolves when the category settings have been applied.
+ */
 async function applyCategorySettings(
   iModel: IModelConnection,
   viewState: ViewState,
   viewData: ViewData,
-  settings?: ElementSettings,
+  settings?: ApplyVisibilitySettings,
 ): Promise<void> {
   const addCategories: Id64Array = [];
   const dropCategories: Id64Array = [];


### PR DESCRIPTION
Rework models and categories fallback--ie, editing settings for how to handle enabled, disabled, and other models/categories that aren't specified in the saved view.

Deleted the fallback option from settings and added
models: {
    enabled: bool,
    disabled: bool,
    other: bool
}
categories: {
    enabled: bool,
    disabled: bool,
    other: bool
}